### PR TITLE
refactor: shortened code and hopefully make more readable

### DIFF
--- a/packages/lambda-powertools-middleware-obfuscater/obfuscate.js
+++ b/packages/lambda-powertools-middleware-obfuscater/obfuscate.js
@@ -1,15 +1,13 @@
 const _ = require('lodash/fp')
 
 function convertToObfuscatedEvent (event, fieldsToObfuscate) {
-  const obfuscatedObject = _.flow(
+  return _.flow(
     _.map(getUnobfuscatedObject(event)), // Retrieve the path to the object to obfuscate { a.b.c.**** }
     _.map(obfuscate), // Iterate through everything
     _.mergeAll, // Merge them all together creating one unified element
-    removeEmptyObjects // If any have returned an empty object, remove them as they are to be ignored
+    removeEmptyObjects, // If any have returned an empty object, remove them as they are to be ignored
+    _.merge(event) // Deep merge the event and obfuscated event together
   )(fieldsToObfuscate)
-
-  // Deep merge the event and obfuscation together - returning an obfuscated event
-  return _.merge(event, obfuscatedObject)
 }
 
 // returns the object from the fieldName


### PR DESCRIPTION
As I was thinking about this I realised that I was applying a lot of redundant steps, and that it could be simplified by returning the shortest path to the object you wish to obfuscate, obfuscating that recursively, and then merging together. 

This both shortens the code, by quite a lot, but also makes the code more readable. 