### PR TITLE
refactor(logger): reorder params for readability in cloudwatch logs

### DIFF
--- a/packages/lambda-powertools-logger/index.js
+++ b/packages/lambda-powertools-logger/index.js
@@ -71,7 +71,8 @@ class Logger {
       message
     }
 
-    console.log(JSON.stringify(logMsg))
+    // re-order message and params to appear earlier in the log row
+    console.log(JSON.stringify({ message, ...params, ...logMsg }))
   }
 
   debug (msg, params) {


### PR DESCRIPTION
Currently the cloudwatch logs show the environment variables first and truncate the more useful bits. To see the message and params one has to open up each of the row in the logs. 

![image](https://user-images.githubusercontent.com/16896437/53564080-d004b200-3b4d-11e9-8786-b4ffa4b98fc9.png)

By re-ordering the message and params we can have these shown first to allow quicker browsing through the logs.