### PR TITLE
feat(logger): include filename & line in log.debug

### DIFF
--- a/packages/lambda-powertools-logger/index.js
+++ b/packages/lambda-powertools-logger/index.js
@@ -76,7 +76,12 @@ class Logger {
   }
 
   debug (msg, params) {
-    this.log('DEBUG', msg, params)
+    const src = new Error().stack
+      .toString()
+      .split('\n')[3] // pick the level in the stack, just outside logger
+      .match(/\((.+)\)/)[1];
+    
+    this.log('DEBUG', msg, { ...params, src })
   }
 
   info (msg, params) {


### PR DESCRIPTION
In debug logs it is useful to identify where the log message originated from i.e. filename and line number.