### PR TITLE
refactor(security): update lodash after security alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4050,8 +4050,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4072,14 +4071,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4094,20 +4091,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4224,8 +4218,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4237,7 +4230,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4252,7 +4244,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4260,14 +4251,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -4286,7 +4275,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4367,8 +4355,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4380,7 +4367,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4466,8 +4452,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4503,7 +4488,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4523,7 +4507,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4567,14 +4550,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},

--- a/packages/lambda-powertools-middleware-correlation-ids/package-lock.json
+++ b/packages/lambda-powertools-middleware-correlation-ids/package-lock.json
@@ -1,9 +1,22 @@
 {
   "name": "@perform/lambda-powertools-middleware-correlation-ids",
-  "version": "0.10.0",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@perform/lambda-powertools-correlation-ids": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@perform/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.0.0.tgz",
+      "integrity": "sha512-y74YlG4ZD4+nywThU48ctBVGs6li/eRpvUImCHEKGW2d/sIn+aRO4hKhuyE5XWiSYF3pmDN5GbsqGm32iyj6Xw=="
+    },
+    "@perform/lambda-powertools-logger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@perform/lambda-powertools-logger/-/lambda-powertools-logger-1.0.1.tgz",
+      "integrity": "sha512-EWeC1JFHotb6BABUXhHn5U5sHSqm/y61qYJ36i9z3MU0SUZY2hqsWCPCSehL2KxYAt1riZLGLTdeQZoIgWDPCw==",
+      "requires": {
+        "@perform/lambda-powertools-correlation-ids": "^1.0.0"
+      }
+    },
     "@types/aws-lambda": {
       "version": "8.10.6",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.6.tgz",
@@ -95,9 +108,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "middy": {

--- a/packages/lambda-powertools-middleware-correlation-ids/package.json
+++ b/packages/lambda-powertools-middleware-correlation-ids/package.json
@@ -12,7 +12,7 @@
     "@perform/lambda-powertools-logger": "^1.0.1"
   },
   "devDependencies": {
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "middy": "^0.15.6",
     "uuid": "^3.2.1"
   }

--- a/packages/lambda-powertools-middleware-obfuscater/package-lock.json
+++ b/packages/lambda-powertools-middleware-obfuscater/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@perform/lambda-powertools-middleware-obfuscater",
-  "version": "1.0.1",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1652,8 +1652,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1674,14 +1673,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1696,20 +1693,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1826,8 +1820,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1839,7 +1832,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1854,7 +1846,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1862,14 +1853,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1888,7 +1877,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1969,8 +1957,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1982,7 +1969,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2068,8 +2054,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2105,7 +2090,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2125,7 +2109,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2169,14 +2152,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/packages/lambda-powertools-middleware-obfuscater/package-lock.json
+++ b/packages/lambda-powertools-middleware-obfuscater/package-lock.json
@@ -3412,7 +3412,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/packages/lambda-powertools-middleware-obfuscater/package.json
+++ b/packages/lambda-powertools-middleware-obfuscater/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.0.0",
     "@perform/lambda-powertools-logger": "^1.0.1",
-    "lodash": " ^4.17.11"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "jest": "^23.1.0",

--- a/packages/lambda-powertools-middleware-obfuscater/package.json
+++ b/packages/lambda-powertools-middleware-obfuscater/package.json
@@ -9,8 +9,7 @@
   "author": "Tom Rogers",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.0.0",
-    "@perform/lambda-powertools-logger": "^1.0.1",
-    "lodash": "^4.17.11"
+    "@perform/lambda-powertools-logger": "^1.0.1"
   },
   "devDependencies": {
     "jest": "^23.1.0",


### PR DESCRIPTION
## What did you implement:

Updated dependency on lodash to latest version (4.17.11) as it 4.17.10 has security alerts.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
