### PR TITLE
feat: add log-timeout middleware

### DIFF
--- a/packages/lambda-powertools-middleware-log-timeout/README.md
+++ b/packages/lambda-powertools-middleware-log-timeout/README.md
@@ -4,7 +4,7 @@ A [Middy](https://github.com/middyjs/middy) middleware that will log a timeout e
 
 Main features:
 
-* records an error log message with the invocation event as attribute when an invocation times out
+* records an error log message `invocation timed out` (with the invocation event as attribute) when an invocation times out
 
 ## Getting Started
 
@@ -13,6 +13,8 @@ Install from NPM: `npm install @perform/lambda-powertools-middleware-log-timeout
 Alternatively, if you use the template `@perform/lambda-powertools-pattern-basic` then this would be configured for you.
 
 ## API
+
+The middleware accepts an optional constructor parameter `thresholdMillis`, which is the number of millis before an invocation is timed out, that an error message is logged. `thresholdMillis` defaults to **10ms**.
 
 ```js
 const middy = require('middy')
@@ -23,7 +25,8 @@ const handler = async (event, context) => {
 }
 
 module.exports = middy(handler)
-  .use(logTimeout())
+  // or .use(logTimeout(50)) to log the timeout error message 50ms before invocation times out
+  .use(logTimeout()) // defaults to 10ms
 }
 ```
 

--- a/packages/lambda-powertools-middleware-log-timeout/README.md
+++ b/packages/lambda-powertools-middleware-log-timeout/README.md
@@ -4,7 +4,7 @@ A [Middy](https://github.com/middyjs/middy) middleware that will log a timeout e
 
 Main features:
 
-* records an error log message with the invocation event as attribute when an invocation errors
+* records an error log message with the invocation event as attribute when an invocation times out
 
 ## Getting Started
 
@@ -13,16 +13,6 @@ Install from NPM: `npm install @perform/lambda-powertools-middleware-log-timeout
 Alternatively, if you use the template `@perform/lambda-powertools-pattern-basic` then this would be configured for you.
 
 ## API
-
-Accepts a configuration object of the following shape:
-
-```js
-{
-  // Log the timed out error message this many millis before a function 
-  // actually times out. Defaults to 10ms.
-  thresholdMillis: double
-}
-```
 
 ```js
 const middy = require('middy')

--- a/packages/lambda-powertools-middleware-log-timeout/README.md
+++ b/packages/lambda-powertools-middleware-log-timeout/README.md
@@ -1,0 +1,40 @@
+# lambda-powertools-middleware-log-timeout
+
+A [Middy](https://github.com/middyjs/middy) middleware that will log a timeout error message **just before** the function actually times out.
+
+Main features:
+
+* records an error log message with the invocation event as attribute when an invocation errors
+
+## Getting Started
+
+Install from NPM: `npm install @perform/lambda-powertools-middleware-log-timeout`
+
+Alternatively, if you use the template `@perform/lambda-powertools-pattern-basic` then this would be configured for you.
+
+## API
+
+Accepts a configuration object of the following shape:
+
+```js
+{
+  // Log the timed out error message this many millis before a function 
+  // actually times out. Defaults to 10ms.
+  thresholdMillis: double
+}
+```
+
+```js
+const middy = require('middy')
+const logTimeout = require('@perform/lambda-powertools-middleware-log-timeout')
+
+const handler = async (event, context) => {
+  return 42
+}
+
+module.exports = middy(handler)
+  .use(logTimeout())
+}
+```
+
+It's **recommended** that you use the `@perform/lambda-powertools-pattern-basic` which configures this middleware along with other useful middlewares.

--- a/packages/lambda-powertools-middleware-log-timeout/__tests__/index.js
+++ b/packages/lambda-powertools-middleware-log-timeout/__tests__/index.js
@@ -1,0 +1,67 @@
+const consoleLog = jest.spyOn(global.console, 'log')
+
+const Promise = require('bluebird')
+const middy = require('middy')
+const logTimeoutMiddleware = require('../index')
+
+beforeEach(() => {
+  consoleLog.mockClear()
+})
+
+const invokeSuccessHandler = async () => {
+  const handler = middy(async () => {
+  })
+  handler.use(logTimeoutMiddleware())
+
+  await handler({}, { awsRequestId: 'test-id' }, () => {})
+}
+
+const invokeTimedOutHandler = async (event, awsRequestId) => {
+  const context = {
+    awsRequestId,
+    getRemainingTimeInMillis: () => 20
+  }
+
+  const handler = middy(async () => {
+    await Promise.delay(20)
+  })
+  handler.use(logTimeoutMiddleware())
+
+  await new Promise((resolve) => {
+    handler(event, context, resolve)
+  })
+}
+
+const errorLogWasWritten = (f) => {
+  expect(consoleLog).toBeCalled()
+  const log = JSON.parse(consoleLog.mock.calls[0])
+  expect(log.sLevel).toBe('ERROR')
+  expect(log.level).toBe(50)
+  expect(log.message).toBe('invocation timed out')
+
+  f(log)
+}
+
+describe('Log timeout middleware', () => {
+  describe('when function finishes successfully', () => {
+    it('does not log anything', async () => {
+      await invokeSuccessHandler()
+      expect(consoleLog).not.toBeCalled()
+    })
+  })
+
+  describe('when function times out', () => {
+    it('logs an error message', async () => {
+      const event = { test: 'wat' }
+      const awsRequestId = 'test-id'
+
+      await invokeTimedOutHandler(event, awsRequestId)
+
+      errorLogWasWritten(x => {
+        expect(x.awsRequestId).toBe(awsRequestId)
+        expect(x.invocationEvent).toBeDefined()
+        expect(JSON.parse(x.invocationEvent)).toEqual(event)
+      })
+    })
+  })
+})

--- a/packages/lambda-powertools-middleware-log-timeout/__tests__/index.js
+++ b/packages/lambda-powertools-middleware-log-timeout/__tests__/index.js
@@ -3,7 +3,7 @@ const consoleLog = jest.spyOn(global.console, 'log')
 const middy = require('middy')
 const logTimeoutMiddleware = require('../index')
 
-const delay = (millis) => new Promise((resolve) => setTimeout(resolve, millis))
+jest.useFakeTimers()
 
 beforeEach(() => {
   consoleLog.mockClear()
@@ -20,17 +20,15 @@ const invokeSuccessHandler = async () => {
 const invokeTimedOutHandler = async (event, awsRequestId) => {
   const context = {
     awsRequestId,
-    getRemainingTimeInMillis: () => 20
+    getRemainingTimeInMillis: () => 1000
   }
 
   const handler = middy(async () => {
-    await delay(20)
+    jest.advanceTimersByTime(1000)
   })
   handler.use(logTimeoutMiddleware())
 
-  await new Promise((resolve) => {
-    handler(event, context, resolve)
-  })
+  await handler(event, context, () => {})
 }
 
 const errorLogWasWritten = (f) => {

--- a/packages/lambda-powertools-middleware-log-timeout/__tests__/index.js
+++ b/packages/lambda-powertools-middleware-log-timeout/__tests__/index.js
@@ -1,8 +1,9 @@
 const consoleLog = jest.spyOn(global.console, 'log')
 
-const Promise = require('bluebird')
 const middy = require('middy')
 const logTimeoutMiddleware = require('../index')
+
+const delay = (millis) => new Promise((resolve) => setTimeout(resolve, millis))
 
 beforeEach(() => {
   consoleLog.mockClear()
@@ -23,7 +24,7 @@ const invokeTimedOutHandler = async (event, awsRequestId) => {
   }
 
   const handler = middy(async () => {
-    await Promise.delay(20)
+    await delay(20)
   })
   handler.use(logTimeoutMiddleware())
 

--- a/packages/lambda-powertools-middleware-log-timeout/index.js
+++ b/packages/lambda-powertools-middleware-log-timeout/index.js
@@ -11,7 +11,10 @@ module.exports = (thresholdMillis = 10) => {
         Log.error('invocation timed out', { awsRequestId, invocationEvent })
       }, timeoutMs)
 
-      handler.context.lambdaPowertoolsLogTimeoutMiddleware = {
+      Object.defineProperty(handler.context, 'lambdaPowertoolsLogTimeoutMiddleware', {
+        enumerable: false,
+        value: { timer }
+      });
         timer
       }
 

--- a/packages/lambda-powertools-middleware-log-timeout/index.js
+++ b/packages/lambda-powertools-middleware-log-timeout/index.js
@@ -14,9 +14,7 @@ module.exports = (thresholdMillis = 10) => {
       Object.defineProperty(handler.context, 'lambdaPowertoolsLogTimeoutMiddleware', {
         enumerable: false,
         value: { timer }
-      });
-        timer
-      }
+      })
 
       next()
     },

--- a/packages/lambda-powertools-middleware-log-timeout/index.js
+++ b/packages/lambda-powertools-middleware-log-timeout/index.js
@@ -1,41 +1,24 @@
-const Promise = require('bluebird')
 const Log = require('@perform/lambda-powertools-logger')
 
 module.exports = (thresholdMillis = 10) => {
-  let isTimedOut
-  let promise
-
-  const resetPromise = () => {
-    if (promise) {
-      promise.cancel()
-      promise = undefined
-    }
-  }
-
   return {
     before: (handler, next) => {
       const timeLeft = handler.context.getRemainingTimeInMillis()
-      handler.context.callbackWaitsForEmptyEventLoop = false
-      isTimedOut = undefined
-
-      promise = Promise.delay(timeLeft - thresholdMillis).then(() => {
-        if (isTimedOut !== false) {
-          const awsRequestId = handler.context.awsRequestId
-          const invocationEvent = JSON.stringify(handler.event)
-          Log.error('invocation timed out', { awsRequestId, invocationEvent })
-        }
-      })
+      const timeoutMs = timeLeft - thresholdMillis
+      handler.context.logTimeoutTimer = setTimeout(() => {
+        const awsRequestId = handler.context.awsRequestId
+        const invocationEvent = JSON.stringify(handler.event)
+        Log.error('invocation timed out', { awsRequestId, invocationEvent })
+      }, timeoutMs)
 
       next()
     },
     after: (handler, next) => {
-      isTimedOut = false
-      resetPromise()
+      clearTimeout(handler.context.logTimeoutTimer)
       next()
     },
     onError: (handler, next) => {
-      isTimedOut = false
-      resetPromise()
+      clearTimeout(handler.context.logTimeoutTimer)
       next(handler.error)
     }
   }

--- a/packages/lambda-powertools-middleware-log-timeout/index.js
+++ b/packages/lambda-powertools-middleware-log-timeout/index.js
@@ -1,0 +1,42 @@
+const Promise = require('bluebird')
+const Log = require('@perform/lambda-powertools-logger')
+
+module.exports = (thresholdMillis = 10) => {
+  let isTimedOut
+  let promise
+
+  const resetPromise = () => {
+    if (promise) {
+      promise.cancel()
+      promise = undefined
+    }
+  }
+
+  return {
+    before: (handler, next) => {
+      const timeLeft = handler.context.getRemainingTimeInMillis()
+      handler.context.callbackWaitsForEmptyEventLoop = false
+      isTimedOut = undefined
+
+      promise = Promise.delay(timeLeft - thresholdMillis).then(() => {
+        if (isTimedOut !== false) {
+          const awsRequestId = handler.context.awsRequestId
+          const invocationEvent = JSON.stringify(handler.event)
+          Log.error('invocation timed out', { awsRequestId, invocationEvent })
+        }
+      })
+
+      next()
+    },
+    after: (handler, next) => {
+      isTimedOut = false
+      resetPromise()
+      next()
+    },
+    onError: (handler, next) => {
+      isTimedOut = false
+      resetPromise()
+      next(handler.error)
+    }
+  }
+}

--- a/packages/lambda-powertools-middleware-log-timeout/package-lock.json
+++ b/packages/lambda-powertools-middleware-log-timeout/package-lock.json
@@ -1,0 +1,203 @@
+{
+	"name": "@perform/lambda-powertools-middleware-log-timeout",
+	"version": "1.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@perform/lambda-powertools-correlation-ids": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@perform/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.1.7.tgz",
+			"integrity": "sha512-mGln4U90w9a0AcNsBUZBYIeUC95+kLnUoPEUcFA6rE93582OoqsVcSyx0qt8vtGGqId6BpX+3O5WN/v30SwNiw=="
+		},
+		"@perform/lambda-powertools-logger": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@perform/lambda-powertools-logger/-/lambda-powertools-logger-1.1.7.tgz",
+			"integrity": "sha512-fZz2aZQcB2zFNjrLgviZ7HTcWc9qMunD1k7lO6/sOuFh/F6UpV+Oalnr3qORj3fJtOrx81vSTUZ4G1FCW1vQ7Q==",
+			"requires": {
+				"@perform/lambda-powertools-correlation-ids": "^1.1.7"
+			}
+		},
+		"@types/aws-lambda": {
+			"version": "8.10.26",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.26.tgz",
+			"integrity": "sha512-RI32vdCHAtKaFpjA9Wp2+VGrE4aagsiHhAEopWCcMDZreZjyC26Wlnwu2CZvqycMjKjZ1tLhpHIJC/VmjJIspQ==",
+			"dev": true
+		},
+		"@types/http-errors": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.1.tgz",
+			"integrity": "sha512-s+RHKSGc3r0m3YEE2UXomJYrpQaY9cDmNDLU2XvG1/LAZsQ7y8emYkTLfcw/ByDtcsTyRQKwr76Bj4PkN2hfWg==",
+			"dev": true
+		},
+		"ajv": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ajv-i18n": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-3.4.0.tgz",
+			"integrity": "sha512-le1nxncADqYS+iriLqxnR3iRpyoLQLsnrc7CbbJ8K/E+75kn7uxPH3sz2/n3h5FFLT2cTXP4zDi4uTA2xNt4zQ==",
+			"dev": true
+		},
+		"ajv-keywords": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+			"dev": true
+		},
+		"bluebird": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
+		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"http-errors": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+			"dev": true,
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"json-mask": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/json-mask/-/json-mask-0.3.8.tgz",
+			"integrity": "sha1-LWZBXeFLDovGwVFFVKkL/Kg1aUE=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"middy": {
+			"version": "0.15.10",
+			"resolved": "https://registry.npmjs.org/middy/-/middy-0.15.10.tgz",
+			"integrity": "sha1-RbBik/LxcgTXTYeJS6TrbhyDuVI=",
+			"dev": true,
+			"requires": {
+				"@types/aws-lambda": "^8.10.1",
+				"@types/http-errors": "^1.6.1",
+				"ajv": "^6.0.0",
+				"ajv-i18n": "^3.1.0",
+				"ajv-keywords": "^3.0.0",
+				"content-type": "^1.0.4",
+				"http-errors": "^1.6.2",
+				"json-mask": "^0.3.8",
+				"negotiator": "^0.6.1",
+				"once": "^1.4.0",
+				"qs": "^6.5.0",
+				"querystring": "^0.2.0"
+			}
+		},
+		"negotiator": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+			"dev": true
+		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
+		},
+		"setprototypeof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+			"dev": true
+		},
+		"statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
+		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		}
+	}
+}

--- a/packages/lambda-powertools-middleware-log-timeout/package-lock.json
+++ b/packages/lambda-powertools-middleware-log-timeout/package-lock.json
@@ -53,11 +53,6 @@
 			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
 			"dev": true
 		},
-		"bluebird": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
-		},
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",

--- a/packages/lambda-powertools-middleware-log-timeout/package.json
+++ b/packages/lambda-powertools-middleware-log-timeout/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@perform/lambda-powertools-middleware-log-timeout",
+  "version": "1.0.0",
+  "description": "Middy middleware to log an error message when a function times out.",
+  "author": "Yan Cui <theburningmonk@gmail.com>",
+  "homepage": "https://github.com/getndazn/dazn-lambda-powertools#readme",
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getndazn/dazn-lambda-powertools.git"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "bugs": {
+    "url": "https://github.com/getndazn/dazn-lambda-powertools/issues"
+  },
+  "dependencies": {
+    "@perform/lambda-powertools-logger": "^1.1.7",
+    "bluebird": "^3.5.5"
+  },
+  "devDependencies": {
+    "middy": "^0.15.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/lambda-powertools-middleware-log-timeout/package.json
+++ b/packages/lambda-powertools-middleware-log-timeout/package.json
@@ -17,8 +17,7 @@
     "url": "https://github.com/getndazn/dazn-lambda-powertools/issues"
   },
   "dependencies": {
-    "@perform/lambda-powertools-logger": "^1.1.7",
-    "bluebird": "^3.5.5"
+    "@perform/lambda-powertools-logger": "^1.1.7"
   },
   "devDependencies": {
     "middy": "^0.15.6"

--- a/packages/lambda-powertools-pattern-basic/README.md
+++ b/packages/lambda-powertools-pattern-basic/README.md
@@ -1,6 +1,6 @@
 # lambda-powertools-pattern-basic
 
-A basic pattern that helps you follow our guidelines around logging and monitoring and be a good citizen in DAZN 2.0 :-).
+A basic pattern that helps you follow our guidelines around logging and monitoring.
 
 Main features:
 
@@ -11,6 +11,8 @@ Main features:
 * applies the `@perform/lambda-powertools-middleware-correlation-ids` middleware at 1% sample rate
 
 * applies the `@perform/lambda-powertools-middleware-sample-logging` middleware at 1% sample rate
+
+* applies the `@perform/lambda-powertools-middleware-log-timeout` middleware at default 10ms threshold (i.e. log an error message 10ms before an invocation actually times out)
 
 ## Getting Started
 

--- a/packages/lambda-powertools-pattern-basic/index.js
+++ b/packages/lambda-powertools-pattern-basic/index.js
@@ -1,6 +1,7 @@
 const middy = require('middy')
 const sampleLogging = require('@perform/lambda-powertools-middleware-sample-logging')
 const captureCorrelationIds = require('@perform/lambda-powertools-middleware-correlation-ids')
+const logTimeout = require('@perform/lambda-powertools-middleware-log-timeout')
 
 const AWS_REGION = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION
 const FUNCTION_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME
@@ -17,4 +18,5 @@ module.exports = f => {
   return middy(f)
     .use(captureCorrelationIds({ sampleDebugLogRate: 0.01 }))
     .use(sampleLogging({ sampleRate: 0.01 }))
+    .use(logTimeout())
 }

--- a/packages/lambda-powertools-pattern-basic/package.json
+++ b/packages/lambda-powertools-pattern-basic/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@perform/lambda-powertools-middleware-correlation-ids": "^1.2.0",
     "@perform/lambda-powertools-middleware-sample-logging": "^1.1.7",
+    "@perform/lambda-powertools-middleware-log-timeout": "^1.0.0",
     "middy": "^0.15.0"
   },
   "publishConfig": {

--- a/packages/lambda-powertools-pattern-obfuscate/README.md
+++ b/packages/lambda-powertools-pattern-obfuscate/README.md
@@ -1,6 +1,6 @@
 # lambda-powertools-pattern-obfuscate
 
-A pattern that helps you follow our guidelines around logging and monitoring and be a good citizen in DAZN 2.0 :-) With added ability to obfuscate personal fields. 
+A pattern that helps you follow our guidelines around logging and monitoring. With added ability to obfuscate personal fields.
 
 Main features:
 
@@ -12,8 +12,10 @@ Main features:
 
 * applies the `@perform/lambda-powertools-middleware-sample-logging` middleware at 1% sample rate
 
-* applies the `@perform/lambda-powertools-middleware-obfuscated-logging` middleware with passed obfuscation filters 
- 
+* applies the `@perform/lambda-powertools-middleware-obfuscated-logging` middleware with passed obfuscation filters
+
+* applies the `@perform/lambda-powertools-middleware-log-timeout` middleware at default 10ms threshold (i.e. log an error message 10ms before an invocation actually times out)
+
 ## Getting Started
 
 Install from NPM: `npm install @perform/lambda-powertools-pattern-obfuscate`

--- a/packages/lambda-powertools-pattern-obfuscate/index.js
+++ b/packages/lambda-powertools-pattern-obfuscate/index.js
@@ -2,6 +2,7 @@ const middy = require('middy')
 const sampleLogging = require('@perform/lambda-powertools-middleware-sample-logging')
 const { obfuscaterMiddleware, FILTERING_MODE: obfuscaterFilteringMode } = require('@perform/lambda-powertools-middleware-obfuscater')
 const captureCorrelationIds = require('@perform/lambda-powertools-middleware-correlation-ids')
+const logTimeout = require('@perform/lambda-powertools-middleware-log-timeout')
 
 const AWS_REGION = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION
 const FUNCTION_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME
@@ -53,6 +54,7 @@ const obfuscaterPattern = (obfuscationFilters, f, filterOnAfter = false, filteri
     .use(errorObfuscater(obfuscationFilters, filteringMode))
     .use(sampleLogging({ sampleRate: 0.01, obfuscationFilters }))
     .use(genericObfuscater(obfuscationFilters, filteringMode, filterOnAfter))
+    .use(logTimeout())
 }
 
 module.exports = {

--- a/packages/lambda-powertools-pattern-obfuscate/package.json
+++ b/packages/lambda-powertools-pattern-obfuscate/package.json
@@ -9,6 +9,7 @@
     "@perform/lambda-powertools-middleware-correlation-ids": "^1.2.0",
     "@perform/lambda-powertools-middleware-obfuscater": "^1.1.7",
     "@perform/lambda-powertools-middleware-sample-logging": "^1.1.7",
+    "@perform/lambda-powertools-middleware-log-timeout": "^1.0.0",
     "middy": "^0.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What did you implement:

Added a middleware to log a timeout message just before an invocation is abruptly timed out by Lambda.

## How did you implement it:

Using the same approach outlined in this [post](https://theburningmonk.com/2019/05/how-to-log-timed-out-lambda-invocations/)

## How can we verify it:

Apply the middleware to a function that'll definitely time out, e.g.

```javascript
const middy = require('middy')
const logTimeout = require('@perform/lambda-powertools-middleware-log-timeout')

const handler = (event, context, cb) => {
 // oops, forgot to call callback!
}

module.exports = middy(handler)
  .use(logTimeout())
}
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / projects / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
