### PR TITLE
chore: added MIT license info to all repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "license": "MIT",
   "scripts": {
     "install": "lerna bootstrap",
     "test:lint": "eslint .",

--- a/packages/lambda-powertools-correlation-ids/package.json
+++ b/packages/lambda-powertools-correlation-ids/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.7",
   "description": "Module for recording correlation IDs",
   "main": "index.js",
+  "license": "MIT",
   "scripts": {
     "test": "jest"
   },

--- a/packages/lambda-powertools-http-client/package.json
+++ b/packages/lambda-powertools-http-client/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/dazn-datadog-metrics": "^1.0.0",

--- a/packages/lambda-powertools-kinesis-client/package.json
+++ b/packages/lambda-powertools-kinesis-client/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.1.7",

--- a/packages/lambda-powertools-lambda-client/package.json
+++ b/packages/lambda-powertools-lambda-client/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.1.7",

--- a/packages/lambda-powertools-logger/package.json
+++ b/packages/lambda-powertools-logger/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.1.7"

--- a/packages/lambda-powertools-middleware-correlation-ids/package.json
+++ b/packages/lambda-powertools-middleware-correlation-ids/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.1.7",

--- a/packages/lambda-powertools-middleware-obfuscater/package.json
+++ b/packages/lambda-powertools-middleware-obfuscater/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Tom Rogers",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.1.7",

--- a/packages/lambda-powertools-middleware-sample-logging/package.json
+++ b/packages/lambda-powertools-middleware-sample-logging/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.1.7",

--- a/packages/lambda-powertools-pattern-basic/package.json
+++ b/packages/lambda-powertools-pattern-basic/package.json
@@ -4,6 +4,7 @@
   "description": "Basic template that configures a 1% smaple rate for debug logs",
   "main": "index.js",
   "scripts": {},
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-middleware-correlation-ids": "^1.2.0",

--- a/packages/lambda-powertools-pattern-obfuscate/package.json
+++ b/packages/lambda-powertools-pattern-obfuscate/package.json
@@ -4,6 +4,7 @@
   "description": "Basic template that configures a 1% smaple rate for debug logs and obfuscation",
   "main": "index.js",
   "scripts": {},
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-middleware-correlation-ids": "^1.2.0",

--- a/packages/lambda-powertools-sns-client/package.json
+++ b/packages/lambda-powertools-sns-client/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.1.7",

--- a/packages/lambda-powertools-sqs-client/package.json
+++ b/packages/lambda-powertools-sqs-client/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.1.7",

--- a/packages/lambda-powertools-step-functions-client/package.json
+++ b/packages/lambda-powertools-step-functions-client/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest"
   },
+  "license": "MIT",
   "author": "Yan Cui",
   "dependencies": {
     "@perform/lambda-powertools-correlation-ids": "^1.1.7",


### PR DESCRIPTION
## What did you implement:

Added MIT license to all packages as currently none of them have a license, e.g.
![image](https://user-images.githubusercontent.com/546969/59072333-894bf400-88c2-11e9-955e-1a243d62ef16.png)

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
