### PR TITLE
ci(drone): force setup with node v10.15

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ pipeline:
     when:
       event: [ push, deployment ]
   setup:
-    image: node:10-alpine
+    image: node:10.15-alpine
     when:
       event: push
     commands:


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Node v10.16 was recently released with npm@6.9.0 bundled with it.

npm@6.9.0 has a [serious issue breaking our CI pipeline](https://github.com/npm/cli/pull/173#issuecomment-498020090), so let's avoid it by downgrading to Node v10.15 which is bundled with npm@6.4.1

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Downgrading Node (and therefore npm) to the last working version. Should be a temporary measure until npm@6.9.1 is released.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Drone pipeline is now passing again.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / projects / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
