### PR TITLE
feat: track call-chain length and stop infinite loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ An integrated suite of powertools for Lambda functions to make it effortless for
 
 * [sample logging middleware](/packages/lambda-powertools-middleware-sample-logging): enable debug logging for 1% of invocations, or when upstream caller has made the decision to enable debug logging
 
-* [obfuscater middleware](/packages/lambda-powertools-middleware-obfuscater): allows you to obfuscate the invocation event so that sensitive data (e.g. PII) is not logged accidentally.
+* [obfuscater middleware](/packages/lambda-powertools-middleware-obfuscater): allows you to obfuscate the invocation event so that sensitive data (e.g. PII) is not logged accidentally
 
-* [log timeout middleware](/packages/lambda-powertools-middleware-log-timeout): logs an error message when a function invocation times out.
+* [log timeout middleware](/packages/lambda-powertools-middleware-log-timeout): logs an error message when a function invocation times out
+
+* [stop infinite loop middleware](/packages/lambda-powertools-middleware-stop-infinite-loop): stops infinite loops
 
 ### Client libraries
 

--- a/packages/lambda-powertools-middleware-correlation-ids/index.js
+++ b/packages/lambda-powertools-middleware-correlation-ids/index.js
@@ -4,6 +4,7 @@ const Log = require('@perform/lambda-powertools-logger')
 const X_CORRELATION_ID = 'x-correlation-id'
 const DEBUG_LOG_ENABLED = 'debug-log-enabled'
 const USER_AGENT = 'User-Agent'
+const CALL_CHAIN_LENGTH = 'call-chain-length'
 
 function captureHttp ({ headers }, { awsRequestId }, sampleDebugLogRate) {
   if (!headers) {
@@ -33,6 +34,12 @@ function captureHttp ({ headers }, { awsRequestId }, sampleDebugLogRate) {
     correlationIds[DEBUG_LOG_ENABLED] = Math.random() < sampleDebugLogRate ? 'true' : 'false'
   }
 
+  if (headers[CALL_CHAIN_LENGTH]) {
+    correlationIds[CALL_CHAIN_LENGTH] = parseInt(headers[CALL_CHAIN_LENGTH]) + 1
+  } else {
+    correlationIds[CALL_CHAIN_LENGTH] = 1 // start with 1, i.e. first call in the chain
+  }
+
   CorrelationIds.replaceAllWith(correlationIds)
 }
 
@@ -49,6 +56,8 @@ function captureSns ({ Records }, { awsRequestId }, sampleDebugLogRate) {
       correlationIds[USER_AGENT] = msgAttributes[USER_AGENT].Value
     } else if (msgAttribute === DEBUG_LOG_ENABLED) {
       correlationIds[DEBUG_LOG_ENABLED] = msgAttributes[DEBUG_LOG_ENABLED].Value
+    } else if (msgAttribute === CALL_CHAIN_LENGTH) {
+      correlationIds[CALL_CHAIN_LENGTH] = parseInt(msgAttributes[CALL_CHAIN_LENGTH].Value) + 1
     }
   }
 
@@ -58,6 +67,10 @@ function captureSns ({ Records }, { awsRequestId }, sampleDebugLogRate) {
 
   if (!correlationIds[DEBUG_LOG_ENABLED]) {
     correlationIds[DEBUG_LOG_ENABLED] = Math.random() < sampleDebugLogRate ? 'true' : 'false'
+  }
+
+  if (!correlationIds[CALL_CHAIN_LENGTH]) {
+    correlationIds[CALL_CHAIN_LENGTH] = 1
   }
 
   CorrelationIds.replaceAllWith(correlationIds)
@@ -97,6 +110,8 @@ function captureSqs (event, context, sampleDebugLogRate) {
         correlationIds[USER_AGENT] = msgAttributes[USER_AGENT].stringValue
       } else if (msgAttribute === DEBUG_LOG_ENABLED) {
         correlationIds[DEBUG_LOG_ENABLED] = msgAttributes[DEBUG_LOG_ENABLED].stringValue
+      } else if (msgAttribute === CALL_CHAIN_LENGTH) {
+        correlationIds[CALL_CHAIN_LENGTH] = parseInt(msgAttributes[CALL_CHAIN_LENGTH].stringValue) + 1
       }
     }
 
@@ -106,6 +121,10 @@ function captureSqs (event, context, sampleDebugLogRate) {
 
     if (!correlationIds[DEBUG_LOG_ENABLED]) {
       correlationIds[DEBUG_LOG_ENABLED] = Math.random() < sampleDebugLogRate ? 'true' : 'false'
+    }
+
+    if (!correlationIds[CALL_CHAIN_LENGTH]) {
+      correlationIds[CALL_CHAIN_LENGTH] = 1
     }
 
     const correlationIdsInstance = new CorrelationIds(correlationIds)
@@ -154,6 +173,8 @@ function captureKinesis ({ Records }, context, sampleDebugLogRate) {
           correlationIds[DEBUG_LOG_ENABLED] = Math.random() < sampleDebugLogRate ? 'true' : 'false'
         }
 
+        correlationIds[CALL_CHAIN_LENGTH] = (correlationIds[CALL_CHAIN_LENGTH] || 0) + 1
+
         const correlationIdsInstance = new CorrelationIds(correlationIds)
 
         Object.defineProperties(event, {
@@ -194,6 +215,8 @@ function captureContextField ({ __context__ }, { awsRequestId }, sampleDebugLogR
   if (!correlationIds[DEBUG_LOG_ENABLED]) {
     correlationIds[DEBUG_LOG_ENABLED] = Math.random() < sampleDebugLogRate ? 'true' : 'false'
   }
+
+  correlationIds[CALL_CHAIN_LENGTH] = (correlationIds[CALL_CHAIN_LENGTH] || 0) + 1
 
   CorrelationIds.replaceAllWith(correlationIds)
 }

--- a/packages/lambda-powertools-middleware-correlation-ids/index.js
+++ b/packages/lambda-powertools-middleware-correlation-ids/index.js
@@ -225,6 +225,7 @@ function initCorrelationIds ({ awsRequestId }, sampleDebugLogRate) {
   const correlationIds = { awsRequestId }
   correlationIds[X_CORRELATION_ID] = awsRequestId
   correlationIds[DEBUG_LOG_ENABLED] = Math.random() < sampleDebugLogRate ? 'true' : 'false'
+  correlationIds[CALL_CHAIN_LENGTH] = 1
 
   CorrelationIds.replaceAllWith(correlationIds)
 }

--- a/packages/lambda-powertools-middleware-stop-infinite-loop/README.md
+++ b/packages/lambda-powertools-middleware-stop-infinite-loop/README.md
@@ -1,6 +1,6 @@
 # `lambda-powertools-middleware-stop-infinite-loop`
 
-A [Middy](https://github.com/middyjs/middy) middleware that will stop an invocation if it's deemed to be part of an infinite loop. This middleware is intended to be used alongside `@perform/lambda-powertools-middleware-correlation-ids`, which is responsible for collecting correlation IDs and incrementing the `call-chain-length` (i.e. the number of function invocations that are chained together) at the start of an invocation.
+A [Middy](https://github.com/middyjs/middy) middleware that will stop an invocation if it's deemed to be part of an infinite loop.
 
 Main features:
 
@@ -14,8 +14,13 @@ Install from NPM: `npm install @perform/lambda-powertools-middleware-stop-infini
 
 The middleware accepts an optional constructor parameter `threshold`, which is the max length allowed for the entire call chain.
 
+This middleware is intended to be used alongside `@perform/lambda-powertools-middleware-correlation-ids`, which is responsible for collecting correlation IDs and incrementing the `call-chain-length` (i.e. the number of function invocations that are chained together) at the start of an invocation.
+
+Because this middleware relies on `@perform/lambda-powertools-middleware-correlation-ids`, it needs to be applied **AFTER** `@perform/lambda-powertools-middleware-correlation-ids` (as seen below).
+
 ```js
 const middy = require('middy')
+const correlationIds = require('@perform/lambda-powertools-middleware-correlation-ids')
 const stopInfiniteLoop = require('@perform/lambda-powertools-middleware-stop-infinite-loop')
 
 const handler = async (event, context) => {
@@ -23,6 +28,7 @@ const handler = async (event, context) => {
 }
 
 module.exports = middy(handler)
+  .use(correlationIds())
   .use(stopInfiniteLoop()) // defaults to 10
 }
 ```

--- a/packages/lambda-powertools-middleware-stop-infinite-loop/README.md
+++ b/packages/lambda-powertools-middleware-stop-infinite-loop/README.md
@@ -1,0 +1,28 @@
+# `lambda-powertools-middleware-stop-infinite-loop`
+
+A [Middy](https://github.com/middyjs/middy) middleware that will stop an invocation if it's deemed to be part of an infinite loop. This middleware is intended to be used alongside `@perform/lambda-powertools-middleware-correlation-ids`, which is responsible for collecting correlation IDs and incrementing the `call-chain-length` (i.e. the number of function invocations that are chained together) at the start of an invocation.
+
+Main features:
+
+* errors if the `call-chain-length` reaches the configured threshold (defaults to `10`)
+
+## Getting Started
+
+Install from NPM: `npm install @perform/lambda-powertools-middleware-stop-infinite-loop`
+
+## API
+
+The middleware accepts an optional constructor parameter `threshold`, which is the max length allowed for the entire call chain.
+
+```js
+const middy = require('middy')
+const stopInfiniteLoop = require('@perform/lambda-powertools-middleware-stop-infinite-loop')
+
+const handler = async (event, context) => {
+  return 42
+}
+
+module.exports = middy(handler)
+  .use(stopInfiniteLoop()) // defaults to 10
+}
+```

--- a/packages/lambda-powertools-middleware-stop-infinite-loop/__tests__/index.js
+++ b/packages/lambda-powertools-middleware-stop-infinite-loop/__tests__/index.js
@@ -1,0 +1,59 @@
+const consoleLog = jest.spyOn(global.console, 'log')
+
+const middy = require('middy')
+const CorrelationIds = require('@perform/lambda-powertools-correlation-ids')
+const stopInfiniteLoop = require('../index')
+
+const getHandler = () => middy(async () => {}).use(stopInfiniteLoop(3))
+
+const warnLogWasWritten = (f) => {
+  expect(consoleLog).toBeCalled()
+  const log = JSON.parse(consoleLog.mock.calls[0])
+  expect(log.sLevel).toBe('ERROR')
+  expect(log.level).toBe(50)
+  expect(log.message).toBe('Possible infinite recursion detected, invocation is stopped.')
+
+  f(log)
+}
+
+describe('Stop infinite loop middleware', () => {
+  describe('when call-chain-length is not set', () => {
+    it('does nothing', async () => {
+      const handler = getHandler()
+      await handler({}, {}, () => {})
+
+      expect(consoleLog).not.toBeCalled()
+    })
+  })
+
+  describe('when call-chain-length is below threshold', () => {
+    it('does nothing', async () => {
+      const handler = getHandler()
+
+      CorrelationIds.replaceAllWith({
+        'call-chain-length': 2
+      })
+      await handler({}, {}, () => {})
+
+      expect(consoleLog).not.toBeCalled()
+    })
+  })
+
+  describe('when call-chain-length reaches threshold', () => {
+    it('should throw', async () => {
+      const handler = getHandler()
+      const event = { foo: 'bar' }
+
+      CorrelationIds.replaceAllWith({
+        'call-chain-length': 3
+      })
+      await handler(event, { awsRequestId: 'test' }, () => {})
+
+      warnLogWasWritten(x => {
+        expect(x.awsRequestId).toBe('test')
+        expect(x.invocationEvent).toBeDefined()
+        expect(JSON.parse(x.invocationEvent)).toEqual(event)
+      })
+    })
+  })
+})

--- a/packages/lambda-powertools-middleware-stop-infinite-loop/index.js
+++ b/packages/lambda-powertools-middleware-stop-infinite-loop/index.js
@@ -1,0 +1,18 @@
+const CorrelationIds = require('@perform/lambda-powertools-correlation-ids')
+const Log = require('@perform/lambda-powertools-logger')
+
+module.exports = (threshold = 10) => {
+  return {
+    before: (handler, next) => {
+      const len = CorrelationIds.get()['call-chain-length'] || 1
+      if (len >= threshold) {
+        let awsRequestId = handler.context.awsRequestId
+        let invocationEvent = JSON.stringify(handler.event)
+        Log.error('Possible infinite recursion detected, invocation is stopped.', { awsRequestId, invocationEvent })
+        throw new Error(`'call-chain-length' reached threshold of ${threshold}, possible infinite recursion`)
+      } else {
+        next()
+      }
+    }
+  }
+}

--- a/packages/lambda-powertools-middleware-stop-infinite-loop/package-lock.json
+++ b/packages/lambda-powertools-middleware-stop-infinite-loop/package-lock.json
@@ -1,0 +1,185 @@
+{
+	"name": "lambda-powertools-middleware-stop-infinite-loop",
+	"version": "1.3.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@types/aws-lambda": {
+			"version": "8.10.27",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.27.tgz",
+			"integrity": "sha512-9QjcjORRtgG5KPVHWqGZ0F2Uo/ALUWQ5D7qfJEco0fEjoSbA908w05RXql7YPS72jQ1w6I+pr+8pQPqBPlYnSw==",
+			"dev": true
+		},
+		"@types/http-errors": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.1.tgz",
+			"integrity": "sha512-s+RHKSGc3r0m3YEE2UXomJYrpQaY9cDmNDLU2XvG1/LAZsQ7y8emYkTLfcw/ByDtcsTyRQKwr76Bj4PkN2hfWg==",
+			"dev": true
+		},
+		"ajv": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ajv-i18n": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-3.4.0.tgz",
+			"integrity": "sha512-le1nxncADqYS+iriLqxnR3iRpyoLQLsnrc7CbbJ8K/E+75kn7uxPH3sz2/n3h5FFLT2cTXP4zDi4uTA2xNt4zQ==",
+			"dev": true
+		},
+		"ajv-keywords": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+			"dev": true
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
+		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"http-errors": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+			"dev": true,
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"json-mask": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/json-mask/-/json-mask-0.3.8.tgz",
+			"integrity": "sha1-LWZBXeFLDovGwVFFVKkL/Kg1aUE=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"middy": {
+			"version": "0.15.10",
+			"resolved": "https://registry.npmjs.org/middy/-/middy-0.15.10.tgz",
+			"integrity": "sha1-RbBik/LxcgTXTYeJS6TrbhyDuVI=",
+			"dev": true,
+			"requires": {
+				"@types/aws-lambda": "^8.10.1",
+				"@types/http-errors": "^1.6.1",
+				"ajv": "^6.0.0",
+				"ajv-i18n": "^3.1.0",
+				"ajv-keywords": "^3.0.0",
+				"content-type": "^1.0.4",
+				"http-errors": "^1.6.2",
+				"json-mask": "^0.3.8",
+				"negotiator": "^0.6.1",
+				"once": "^1.4.0",
+				"qs": "^6.5.0",
+				"querystring": "^0.2.0"
+			}
+		},
+		"negotiator": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+			"dev": true
+		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
+		},
+		"setprototypeof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+			"dev": true
+		},
+		"statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
+		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		}
+	}
+}

--- a/packages/lambda-powertools-middleware-stop-infinite-loop/package.json
+++ b/packages/lambda-powertools-middleware-stop-infinite-loop/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@perform/lambda-powertools-middleware-stop-infinite-loop",
+  "version": "1.3.0",
+  "description": "Middy middleware that detects and stops infinite loops",
+  "author": "Yan Cui <theburningmonk@gmail.com>",
+  "homepage": "https://github.com/getndazn/dazn-lambda-powertools#readme",
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getndazn/dazn-lambda-powertools.git"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "bugs": {
+    "url": "https://github.com/getndazn/dazn-lambda-powertools/issues"
+  },
+  "dependencies": {
+    "@perform/lambda-powertools-correlation-ids": "^1.3.0",
+    "@perform/lambda-powertools-logger": "^1.3.0"
+  },
+  "devDependencies": {
+    "middy": "^0.15.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## What did you implement:

Closes #38 

Tracks the length of a call chain and stop infinite loops.

## How did you implement it:

* Updated the `correlation-ids` middleware so that it initializes a `call-chain-length`and includes it as part of the correlation IDs (which would be forwarded by other client libs).
* Added a new `stop-infinite-loop` middleware, which inspects the `call-chain-length` correlation ID and throws (before invocating the user code) if it has reached the configured threshold.

## How can we verify it:

* set up a function which recurses indefinitely
* apply this middleware
* see that after X recursions, the function is stopped

![image](https://user-images.githubusercontent.com/546969/59528752-fff67c00-8ed6-11e9-8076-1fd7701dab97.png)

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / projects / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
