### PR TITLE
fix: fixes datadog tags overwritten

### DIFF
--- a/packages/lambda-powertools-pattern-basic/__tests__/index.js
+++ b/packages/lambda-powertools-pattern-basic/__tests__/index.js
@@ -32,7 +32,7 @@ describe('basic pattern', () => {
   describe('when there are no overrides', () => {
     it('should set sample debug log rate to 0.01', async () => {
       const wrap = require('../index')
-      const handler = util.promisify(wrap(async () => {}))
+      const handler = util.promisify(wrap(async () => { }))
       await handler({}, {})
       expect(CaptureCorrelationIds).toHaveBeenCalledWith({ sampleDebugLogRate: 0.01 })
       expect(SampleLogging).toHaveBeenCalledWith({ sampleRate: 0.01 })
@@ -46,7 +46,7 @@ describe('basic pattern', () => {
 
     it('should set sample debug log rate to 0.03', async () => {
       const wrap = require('../index')
-      const handler = util.promisify(wrap(async () => {}))
+      const handler = util.promisify(wrap(async () => { }))
       await handler({}, {})
       expect(CaptureCorrelationIds).toHaveBeenCalledWith({ sampleDebugLogRate: 0.03 })
       expect(SampleLogging).toHaveBeenCalledWith({ sampleRate: 0.03 })

--- a/packages/lambda-powertools-pattern-basic/__tests__/supplement-csv.js
+++ b/packages/lambda-powertools-pattern-basic/__tests__/supplement-csv.js
@@ -1,0 +1,71 @@
+const supplementCsv = require('../supplement-csv')
+
+describe('supplement csv', () => {
+  describe('when there are no existing items defined', () => {
+    it('should return blank string when nothing to add', () => {
+      const expected = ''
+
+      const actual = supplementCsv()
+
+      expect(actual).toEqual(expected)
+    })
+
+    it('should return csv string of key value pairs provided', () => {
+      const expected = 'key1:value1,key2:value2,key3:value3'
+      const inputs = {
+        additional: 'key1:value1,key2:value2,key3:value3'
+      }
+
+      const actual = supplementCsv(inputs)
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('when there are no items to add', () => {
+    it('should return existing csv string', () => {
+      const expected = 'key1:value1,key2:value2,key3:value3'
+      const inputs = {
+        existing: 'key1:value1,key2:value2,key3:value3'
+      }
+
+      const actual = supplementCsv(inputs)
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('when there is an existing csv string', () => {
+    it('should supplement with items to add', () => {
+      const expected = 'key1:value1,key2:value2,key3:value3,key4:value4,key5:value5,key6:value6'.split(',')
+      const inputs = {
+        existing: 'key1:value1,key2:value2,key3:value3',
+        additional: 'key4:value4,key5:value5,key6:value6'
+      }
+
+      const actual = supplementCsv(inputs).split(',')
+
+      actual.forEach(pair => {
+        expect(expected).toContainEqual(pair)
+      })
+
+      expect(actual.length).toEqual(expected.length)
+    })
+
+    it('should not overwrite existing keys with items to add', () => {
+      const expected = 'key1:value1,key2:value2,key3:value3,key5:value5,key6:value6'.split(',')
+      const inputs = {
+        existing: 'key1:value1,key2:value2,key3:value3',
+        additional: 'key1:newValue1,key5:value5,key6:value6'
+      }
+
+      const actual = supplementCsv(inputs).split(',')
+
+      actual.forEach(pair => {
+        expect(expected).toContainEqual(pair)
+      })
+
+      expect(actual.length).toEqual(expected.length)
+    })
+  })
+})

--- a/packages/lambda-powertools-pattern-basic/__tests__/supplement-csv.js
+++ b/packages/lambda-powertools-pattern-basic/__tests__/supplement-csv.js
@@ -13,7 +13,11 @@ describe('supplement csv', () => {
     it('should return csv string of key value pairs provided', () => {
       const expected = 'key1:value1,key2:value2,key3:value3'
       const inputs = {
-        additional: 'key1:value1,key2:value2,key3:value3'
+        additional: {
+          key1: 'value1',
+          key2: 'value2',
+          key3: 'value3'
+        }
       }
 
       const actual = supplementCsv(inputs)
@@ -37,35 +41,102 @@ describe('supplement csv', () => {
 
   describe('when there is an existing csv string', () => {
     it('should supplement with items to add', () => {
-      const expected = 'key1:value1,key2:value2,key3:value3,key4:value4,key5:value5,key6:value6'.split(',')
+      const expected = [
+        'key1:value1',
+        'key2:value2',
+        'key3:value3',
+        'key4:value4',
+        'key5:value5',
+        'key6:value6'
+      ]
+
       const inputs = {
         existing: 'key1:value1,key2:value2,key3:value3',
-        additional: 'key4:value4,key5:value5,key6:value6'
+        additional: {
+          key4: 'value4',
+          key5: 'value5',
+          key6: 'value6'
+        }
       }
 
-      const actual = supplementCsv(inputs).split(',')
+      const actual = supplementCsv(inputs)
 
-      actual.forEach(pair => {
-        expect(expected).toContainEqual(pair)
-      })
-
-      expect(actual.length).toEqual(expected.length)
+      expected.forEach(value =>
+        expect(actual).toEqual(expect.stringContaining(value))
+      )
     })
 
     it('should not overwrite existing keys with items to add', () => {
-      const expected = 'key1:value1,key2:value2,key3:value3,key5:value5,key6:value6'.split(',')
+      const expected = [
+        'key1:value1',
+        'key2:value2',
+        'key3:value3',
+        'key5:value5',
+        'key6:value6'
+      ]
+
       const inputs = {
         existing: 'key1:value1,key2:value2,key3:value3',
-        additional: 'key1:newValue1,key5:value5,key6:value6'
+        additional: {
+          key1: 'newValue1',
+          key5: 'value5',
+          key6: 'value6'
+        }
       }
 
-      const actual = supplementCsv(inputs).split(',')
+      const actual = supplementCsv(inputs)
 
-      actual.forEach(pair => {
-        expect(expected).toContainEqual(pair)
-      })
+      expected.forEach(value =>
+        expect(actual).toEqual(expect.stringContaining(value))
+      )
+    })
 
-      expect(actual.length).toEqual(expected.length)
+    it('should allow values that include a colon', () => {
+      const expected = [
+        'key1:value1:subValue1',
+        'key2:value2',
+        'key3:value3',
+        'key5:value5',
+        'key6:value6'
+      ]
+      const inputs = {
+        existing: 'key1:value1:subValue1,key2:value2,key3:value3',
+        additional: {
+          key1: 'newValue1',
+          key5: 'value5',
+          key6: 'value6'
+        }
+      }
+
+      const actual = supplementCsv(inputs)
+
+      expected.forEach(value =>
+        expect(actual).toEqual(expect.stringContaining(value))
+      )
+    })
+
+    it('should allow values with no key', () => {
+      const expected = [
+        'value1',
+        'key2:value2',
+        'key3:value3',
+        'key5:value5',
+        'key6:value6'
+      ]
+
+      const inputs = {
+        existing: 'value1,key2:value2,key3:value3',
+        additional: {
+          key5: 'value5',
+          key6: 'value6'
+        }
+      }
+
+      const actual = supplementCsv(inputs)
+
+      expected.forEach(value =>
+        expect(actual).toEqual(expect.stringContaining(value))
+      )
     })
   })
 })

--- a/packages/lambda-powertools-pattern-basic/index.js
+++ b/packages/lambda-powertools-pattern-basic/index.js
@@ -12,7 +12,9 @@ if (!process.env.DATADOG_PREFIX) {
   process.env.DATADOG_PREFIX = FUNCTION_NAME + '.'
 }
 
-process.env.DATADOG_TAGS = `awsRegion:${AWS_REGION},functionName:${FUNCTION_NAME},functionVersion:${FUNCTION_VERSION},environment:${ENV}`
+if (!process.env.DATADOG_TAGS) {
+  process.env.DATADOG_TAGS = `awsRegion:${AWS_REGION},functionName:${FUNCTION_NAME},functionVersion:${FUNCTION_VERSION},environment:${ENV}`
+}
 
 module.exports = f => {
   return middy(f)

--- a/packages/lambda-powertools-pattern-basic/index.js
+++ b/packages/lambda-powertools-pattern-basic/index.js
@@ -2,6 +2,7 @@ const middy = require('middy')
 const sampleLogging = require('@perform/lambda-powertools-middleware-sample-logging')
 const captureCorrelationIds = require('@perform/lambda-powertools-middleware-correlation-ids')
 const logTimeout = require('@perform/lambda-powertools-middleware-log-timeout')
+const supplementCsv = require('./supplement-csv')
 
 const AWS_REGION = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION
 const FUNCTION_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME
@@ -12,24 +13,10 @@ if (!process.env.DATADOG_PREFIX) {
   process.env.DATADOG_PREFIX = FUNCTION_NAME + '.'
 }
 
-const supplementCsv = (existing, toAdd) => {
-  // existing will be in the format '<key1>:<value1>,<key2>:<value2>'
-  // Map requires as [[key1, value1], [key2, value2]]
-  const existingNormalised = existing.split(',').map(pair => pair.split(':'))
-
-  // Assigning to a map to stop any duplicates keys (existing taking precedence)
-  const allTags = new Map([...toAdd, ...existingNormalised])
-
-  // convert back to original csv format
-  return Array.from(allTags).map(i => i.join(':')).join(',')
-}
-
-process.env.DATADOG_TAGS = supplementCsv(process.env.DATADOG_TAGS, [
-  ['awsRegion', AWS_REGION],
-  ['functionName', FUNCTION_NAME],
-  ['functionVersion', FUNCTION_VERSION],
-  ['environment', ENV]
-])
+process.env.DATADOG_TAGS = supplementCsv({
+  existing: process.env.DATADOG_TAGS,
+  additional: `awsRegion:${AWS_REGION},functionName:${FUNCTION_NAME},functionVersion:${FUNCTION_VERSION},environment:${ENV}`
+})
 
 module.exports = f => {
   return middy(f)

--- a/packages/lambda-powertools-pattern-basic/index.js
+++ b/packages/lambda-powertools-pattern-basic/index.js
@@ -15,7 +15,12 @@ if (!process.env.DATADOG_PREFIX) {
 
 process.env.DATADOG_TAGS = supplementCsv({
   existing: process.env.DATADOG_TAGS,
-  additional: `awsRegion:${AWS_REGION},functionName:${FUNCTION_NAME},functionVersion:${FUNCTION_VERSION},environment:${ENV}`
+  additional: {
+    awsRegion: AWS_REGION,
+    functionName: FUNCTION_NAME,
+    functionVersion: FUNCTION_VERSION,
+    environment: ENV
+  }
 })
 
 module.exports = f => {

--- a/packages/lambda-powertools-pattern-basic/supplement-csv.js
+++ b/packages/lambda-powertools-pattern-basic/supplement-csv.js
@@ -1,0 +1,23 @@
+const csvToKeyValuesArray = csv =>
+  csv.split(',').filter(x => x).map(pair => pair.split(':'))
+
+const keyValuesArrayToCsv = pairs =>
+  pairs.map(x => x.join(':')).join(',')
+
+const combineUniqueKeyValueArray = (original, additional) =>
+  Array.from(new Map([...original, ...additional]))
+
+const supplementCsv = ({ existing = '', additional = '' } = {}) => {
+  // parameters will be in the format '<key1>:<value1>,<key2>:<value2>'
+  // Map requires as [[key1, value1], [key2, value2]]
+  const existingNormalised = csvToKeyValuesArray(existing)
+  const additionalNormalised = csvToKeyValuesArray(additional)
+
+  // Assigning to a map to stop any duplicates keys (existing taking precedence)
+  const allTags = combineUniqueKeyValueArray(additionalNormalised, existingNormalised)
+
+  // convert back to original csv format
+  return keyValuesArrayToCsv(allTags)
+}
+
+module.exports = supplementCsv

--- a/packages/lambda-powertools-pattern-basic/supplement-csv.js
+++ b/packages/lambda-powertools-pattern-basic/supplement-csv.js
@@ -1,23 +1,52 @@
-const csvToKeyValuesArray = csv =>
-  csv.split(',').filter(x => x).map(pair => pair.split(':'))
+// Given a CSV in form 'key1:value1,key2:value2:subValue2,value3,...,keyn:valuen, valuem'
+// will extract the key value pairs and values:
+// {
+//   keyValues: { key1: 'value1', key2: 'value2:subValue2', ..., keyn: 'valuen'},
+//   values: ['value3', ..., 'valuem']
+// }
+const extractFromCsv = csv =>
+  csv.split(',').reduce((acc, item) => {
+    const parts = item.split(':')
 
-const keyValuesArrayToCsv = pairs =>
-  pairs.map(x => x.join(':')).join(',')
+    if (parts.length > 1) {
+      const [key, ...values] = parts
+      acc.keyValues.push([key, values.join(':')])
+    } else {
+      acc.values.push(item)
+    }
 
-const combineUniqueKeyValueArray = (original, additional) =>
-  Array.from(new Map([...original, ...additional]))
+    return acc
+  }, { keyValues: [], values: [] })
 
-const supplementCsv = ({ existing = '', additional = '' } = {}) => {
+const combineKeyValuePair = pair => pair.join(':')
+
+// Given keyValues of the form { key1: 'value1', key2: 'value2:subValue2', ..., keyn: 'valuen'}
+// and values of form ['value3', ..., 'valuem']
+// will combine back to csv of form 'key1:value1,key2:value2:subValue2,value3,...,keyn:valuen,valuem'
+const buildCsv = ({ keyValues, values }) =>
+  [
+    ...keyValues.map(combineKeyValuePair),
+    ...values
+  ]
+    .filter(x => x) // Either keyValues or values could be []
+    .join(',')
+
+// Combines two arrays in format [[key1, value1], [key2, value2], ..., [keyn, valuen]]
+// Ensures that existing has precedence over additional WRT key name clashes
+const combineUniqueKeyValueArray = (existing, additional) =>
+  Array.from(new Map([...additional, ...existing]))
+
+const supplementCsv = ({ existing = '', additional = {} } = {}) => {
   // parameters will be in the format '<key1>:<value1>,<key2>:<value2>'
   // Map requires as [[key1, value1], [key2, value2]]
-  const existingNormalised = csvToKeyValuesArray(existing)
-  const additionalNormalised = csvToKeyValuesArray(additional)
+  const { keyValues, values } = extractFromCsv(existing)
+  const additionalNormalised = Object.entries(additional)
 
   // Assigning to a map to stop any duplicates keys (existing taking precedence)
-  const allTags = combineUniqueKeyValueArray(additionalNormalised, existingNormalised)
+  const allTags = combineUniqueKeyValueArray(keyValues, additionalNormalised)
 
-  // convert back to original csv format
-  return keyValuesArrayToCsv(allTags)
+  // convert back to original csv format but DOES NOT make any guarantees about order
+  return buildCsv({ keyValues: allTags, values })
 }
 
 module.exports = supplementCsv


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #41 

Doesn't overwrite `process.env.DATADOG_TAGS`

## How did you implement it:

Only assigns `process.env.DATADOG_TAGS` if they have not been assigned

## How can we verify it:

This is a very trivial bug fix and so hopefully this is out of scope.
<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / projects / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
