### PR TITLE
docs: README text `that one decision to start debugging` is confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Instead of forcing you to use our own AWS clients, we could have monkey patched 
 
 We can apply these monkey patching when you apply the correlation IDs middleware, and your function would automagically forward correlation IDs without having to use our own client libraries. That way, as a user of the tools, I can use whatever HTTP client I wish, and can use the standard SDK clients as well.
 
-We did entertain this idea, but I wanted to leave at least one decision for you to make. The rationale is that when things go wrong (e.g. unhandled error, or bug in our wrapper code) or when they don't work as expected (e.g. you're using an AWS SDK client that we don't support yet), at least you have that one decision (in the form of a `require` statement) to start debugging.
+We did entertain this idea, but I wanted to leave at least one decision for you to make. The rationale is that when things go wrong (e.g. unhandled error, or bug in our wrapper code) or when they don't work as expected (e.g. you're using an AWS SDK client that we don't support yet), at least you have that one decision to start debugging (change the `require` statement to use the official library instead of our own to see if things things still work).
 
 ## Useful Lerna CLI commands
 


### PR DESCRIPTION
## What did you implement:

The line that says that you still have `that one decision to start debugging` is a little confusing, and the text in parenthesis does not clarify things up. Here is a re-wording of the text with what I understood was the intended effect.

But I'm not 100% sure =P.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
