### PR TITLE
feat(logger): make params optional when logging the error stack

### DIFF
--- a/packages/lambda-powertools-logger/README.md
+++ b/packages/lambda-powertools-logger/README.md
@@ -33,10 +33,12 @@ Log.info('this is an info message with attributes', { userId: 'theburningmonk' }
 
 Log.warn('this is a warning message')
 Log.warn('this is a warning message with attributes', { userId: 'theburningmonk' })
+Log.warn('this is a warning message', new Error('oops'))
 Log.warn('this is a warning message with attributes, and error details', { userId: 'theburningmonk' }, new Error('oops'))
 
 Log.error('this is an error message')
 Log.error('this is an error message with attributes', { userId: 'theburningmonk' })
+Log.error('this is an error message', new Error('oops'))
 Log.error('this is an error message with attributes, and error details', { userId: 'theburningmonk' }, new Error('oops'))
 ```
 

--- a/packages/lambda-powertools-logger/__tests__/index.js
+++ b/packages/lambda-powertools-logger/__tests__/index.js
@@ -65,6 +65,15 @@ const errorsAreIncluded = log => {
   })
 }
 
+const errorsAreIncludedButNotParams = log => {
+  log('test', new Error('boom'))
+  verify(x => {
+    expect(x.errorName).toBe('Error')
+    expect(x.errorMessage).toBe('boom')
+    expect(x).toHaveProperty('stackTrace')
+  })
+}
+
 const enabledAt = (method, enabledLevels) => {
   const expected = new Set(enabledLevels)
   const allLevels = [ 'DEBUG', 'INFO', 'WARN', 'ERROR' ]
@@ -115,9 +124,14 @@ describe('Logger', () => {
     })
   })
 
-  describe('Error details', () => {
+  describe('Error details with params included', () => {
     it('includes error details in warn logs', () => errorsAreIncluded(Log.warn))
     it('includes error details in error logs', () => errorsAreIncluded(Log.error))
+  })
+
+  describe('Error details with params NOT included', () => {
+    it('includes error details in warn logs', () => errorsAreIncludedButNotParams(Log.warn))
+    it('includes error details in error logs', () => errorsAreIncludedButNotParams(Log.error))
   })
 
   describe('Log level', () => {

--- a/packages/lambda-powertools-logger/index.js
+++ b/packages/lambda-powertools-logger/index.js
@@ -84,11 +84,13 @@ class Logger {
   }
 
   warn (msg, params, err) {
-    this.log('WARN', msg, this.appendError(params, err))
+    const parameters = !err && params instanceof Error ? this.appendError({}, params) : this.appendError(params, err)
+    this.log('WARN', msg, parameters)
   }
 
   error (msg, params, err) {
-    this.log('ERROR', msg, this.appendError(params, err))
+    const parameters = !err && params instanceof Error ? this.appendError({}, params) : this.appendError(params, err)
+    this.log('ERROR', msg, parameters)
   }
 
   enableDebug () {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## This is a Feature Proposal:

This change is to have the option to log the error details without having to pass the `params` argument when invoking `Logger#warn` or `Logger#error`. It reflects more the `console#error` way which most of developers are used to.

## How did you implement it:

In `Logger#warn` and `Logger#error` functions in case  `err` is not defined and `params` is an instance of `Error`, then the error details will be included in the logging.

## How can we verify it:

Examples:
```javascript
Log.warn('this is a warning message', new Error('oops'))
// or
Log.error('this is an error message', new Error('oops'))
```

Changes are backward compatible.
Both these statements return the same output structure:
```
Log.error('this is an error message', {}, new Error('oops'))
Log.error('this is an error message', new Error('oops'))
```

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / projects / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
