### PR TITLE
fix(log-timeout): check timer is set before attempting to clear

### DIFF
--- a/packages/lambda-powertools-middleware-log-timeout/index.js
+++ b/packages/lambda-powertools-middleware-log-timeout/index.js
@@ -1,6 +1,6 @@
 const Log = require('@dazn/lambda-powertools-logger')
 
-const getTimer = (event, context, thresholdMillis) => {
+const createTimer = (event, context, thresholdMillis) => {
   if (typeof context.getRemainingTimeInMillis !== 'function') {
     return null
   }
@@ -16,10 +16,15 @@ const getTimer = (event, context, thresholdMillis) => {
   return timer
 }
 
+const hasTimer = (context) => {
+  return context.lambdaPowertoolsLogTimeoutMiddleware &&
+    context.lambdaPowertoolsLogTimeoutMiddleware.timer
+}
+
 module.exports = (thresholdMillis = 10) => {
   return {
     before: (handler, next) => {
-      const timer = getTimer(handler.event, handler.context, thresholdMillis)
+      const timer = createTimer(handler.event, handler.context, thresholdMillis)
       Object.defineProperty(handler.context, 'lambdaPowertoolsLogTimeoutMiddleware', {
         enumerable: false,
         value: { timer }
@@ -28,14 +33,14 @@ module.exports = (thresholdMillis = 10) => {
       next()
     },
     after: (handler, next) => {
-      if (handler.context.lambdaPowertoolsLogTimeoutMiddleware.timer) {
+      if (hasTimer(handler.context)) {
         clearTimeout(handler.context.lambdaPowertoolsLogTimeoutMiddleware.timer)
       }
 
       next()
     },
     onError: (handler, next) => {
-      if (handler.context.lambdaPowertoolsLogTimeoutMiddleware.timer) {
+      if (hasTimer(handler.context)) {
         clearTimeout(handler.context.lambdaPowertoolsLogTimeoutMiddleware.timer)
       }
 

--- a/packages/lambda-powertools-middleware-log-timeout/package-lock.json
+++ b/packages/lambda-powertools-middleware-log-timeout/package-lock.json
@@ -1,9 +1,22 @@
 {
 	"name": "@dazn/lambda-powertools-middleware-log-timeout",
-	"version": "1.8.0",
+	"version": "1.8.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.8.2.tgz",
+			"integrity": "sha512-zZvahepZI7vC3qvT+z0eVXbt9gJ6vHK0UJcw2IZ5EOhocYfOJhNsaGIv6HdOp8nDGAQkVLH8IY3Ih/wLoBU4Lg=="
+		},
+		"@dazn/lambda-powertools-logger": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.8.2.tgz",
+			"integrity": "sha512-eXjBsvJwU7lBwBQaxFz9CPoXCodElkptw2iw++UYBLEnjt0ql+jzEU+BRIgBa1w8qESoAXomLppfG2YU+Mr7aw==",
+			"requires": {
+				"@dazn/lambda-powertools-correlation-ids": "^1.8.2"
+			}
+		},
 		"@types/aws-lambda": {
 			"version": "8.10.26",
 			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.26.tgz",


### PR DESCRIPTION
## What did you implement:

Closes #82 #86

Check the timer is set before attempting to run `clearTimer`.

## Todos:

- [x] Write tests
- [x] Make sure code coverage hasn't dropped
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
