### PR TITLE
use API Gateway's requestId to initialize correlation Id

### DIFF
--- a/packages/lambda-powertools-firehose-client/package-lock.json
+++ b/packages/lambda-powertools-firehose-client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dazn/lambda-powertools-firehose-client",
-	"version": "1.8.3",
+	"version": "1.10.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/lambda-powertools-middleware-correlation-ids/__tests__/api-gateway.js
+++ b/packages/lambda-powertools-middleware-correlation-ids/__tests__/api-gateway.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
-const { standardTests } = require('./lib')
+const uuid = require('uuid/v4')
+const { invokeHandler } = require('./lib')
 
 global.console.log = jest.fn()
 
@@ -11,5 +12,91 @@ const genApiGatewayEvent = (correlationIds = {}) => {
 }
 
 describe('Correlation IDs middleware (API Gateway)', () => {
-  standardTests(genApiGatewayEvent)
+  describe('when sampleDebugLogRate = 0', () => {
+    it('always sets debug-log-enabled to false', () => {
+      const requestId = uuid()
+      const event = genApiGatewayEvent()
+      invokeHandler(event, requestId, 0, x => {
+        expect(x['awsRequestId']).toBe(requestId)
+        expect(x['x-correlation-id']).toBe(event.requestContext.requestId)
+        expect(x['debug-log-enabled']).toBe('false')
+      })
+    })
+  })
+
+  describe('when sampleDebugLogRate = 1', () => {
+    it('always sets debug-log-enabled to true', () => {
+      const requestId = uuid()
+      const event = genApiGatewayEvent()
+      invokeHandler(event, requestId, 1, x => {
+        expect(x['awsRequestId']).toBe(requestId)
+        expect(x['x-correlation-id']).toBe(event.requestContext.requestId)
+        expect(x['debug-log-enabled']).toBe('true')
+      })
+    })
+  })
+
+  describe('when correlation ID is not provided in the event', () => {
+    it('sets it to the API Gateway Request ID', () => {
+      const requestId = uuid()
+      const event = genApiGatewayEvent()
+      invokeHandler(event, requestId, 0, x => {
+        expect(x['x-correlation-id']).toBe(event.requestContext.requestId)
+        expect(x['awsRequestId']).toBe(requestId)
+      })
+    })
+  })
+
+  describe('when call-chain-length is not provided in the event', () => {
+    it('sets it to 1', () => {
+      const requestId = uuid()
+      invokeHandler(genApiGatewayEvent(), requestId, 0, x => {
+        expect(x['call-chain-length']).toBe(1)
+      })
+    })
+  })
+
+  describe('when correlation IDs are provided in the event', () => {
+    it('captures them', () => {
+      const id = uuid()
+      const userId = uuid()
+
+      const correlationIds = {
+        'x-correlation-id': id,
+        'x-correlation-user-id': userId,
+        'User-Agent': 'jest test',
+        'debug-log-enabled': 'true'
+      }
+
+      const event = genApiGatewayEvent(correlationIds)
+
+      const requestId = uuid()
+      invokeHandler(event, requestId, 0, x => {
+        expect(x['x-correlation-id']).toBe(id)
+        expect(x['x-correlation-user-id']).toBe(userId)
+        expect(x['User-Agent']).toBe('jest test')
+        expect(x['debug-log-enabled']).toBe('true')
+        expect(x['awsRequestId']).toBe(requestId)
+      })
+    })
+  })
+
+  describe('when call-chain-length is provided in the event', () => {
+    it('increments it by 1', () => {
+      const id = uuid()
+
+      const correlationIds = {
+        'x-correlation-id': id,
+        'call-chain-length': 1
+      }
+
+      const event = genApiGatewayEvent(correlationIds)
+
+      const requestId = uuid()
+      invokeHandler(event, requestId, 0, x => {
+        expect(x['x-correlation-id']).toBe(id)
+        expect(x['call-chain-length']).toBe(2)
+      })
+    })
+  })
 })

--- a/packages/lambda-powertools-middleware-correlation-ids/event-sources/api-gateway.js
+++ b/packages/lambda-powertools-middleware-correlation-ids/event-sources/api-gateway.js
@@ -6,13 +6,14 @@ function isMatch (event) {
   return event.hasOwnProperty('httpMethod')
 }
 
-function captureCorrelationIds ({ headers }, { awsRequestId }, sampleDebugLogRate) {
+function captureCorrelationIds ({ requestContext, headers }, { awsRequestId }, sampleDebugLogRate) {
   if (!headers) {
     Log.warn(`Request ${awsRequestId} is missing headers`)
     return
   }
 
-  const correlationIds = { awsRequestId }
+  const apiGatewayRequestId = requestContext ? requestContext.requestId : undefined
+  const correlationIds = { awsRequestId, apiGatewayRequestId }
   for (const header in headers) {
     if (header.toLowerCase().startsWith('x-correlation-')) {
       correlationIds[header] = headers[header]
@@ -20,7 +21,7 @@ function captureCorrelationIds ({ headers }, { awsRequestId }, sampleDebugLogRat
   }
 
   if (!correlationIds[consts.X_CORRELATION_ID]) {
-    correlationIds[consts.X_CORRELATION_ID] = awsRequestId
+    correlationIds[consts.X_CORRELATION_ID] = apiGatewayRequestId || awsRequestId
   }
 
   // forward the original User-Agent on


### PR DESCRIPTION
## What did you implement:

Closes #92 

## How did you implement it:

* for the API Gateway event source, use the `event.requestContext.requestId` (which is the API Gateway request ID) to initialize as our correlation ID

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
