### PR TITLE
Feature/http keepalive via env vars

### DIFF
--- a/packages/lambda-powertools-firehose-client/index.js
+++ b/packages/lambda-powertools-firehose-client/index.js
@@ -1,18 +1,4 @@
 const AWS = require('aws-sdk')
-const https = require('https')
-const sslAgent = new https.Agent({
-  keepAlive: true,
-  maxSockets: 50,
-  rejectUnauthorized: true
-})
-sslAgent.setMaxListeners(0)
-
-AWS.config.update({
-  httpOptions: {
-    agent: sslAgent
-  }
-})
-
 const client = new AWS.Firehose()
 const Log = require('@dazn/lambda-powertools-logger')
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')

--- a/packages/lambda-powertools-firehose-client/index.js
+++ b/packages/lambda-powertools-firehose-client/index.js
@@ -1,3 +1,4 @@
+process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
 const AWS = require('aws-sdk')
 const client = new AWS.Firehose()
 const Log = require('@dazn/lambda-powertools-logger')

--- a/packages/lambda-powertools-firehose-client/index.js
+++ b/packages/lambda-powertools-firehose-client/index.js
@@ -1,6 +1,6 @@
 process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
-const AWS = require('aws-sdk')
-const client = new AWS.Firehose()
+const Firehose = require('aws-sdk/clients/firehose')
+const client = new Firehose()
 const Log = require('@dazn/lambda-powertools-logger')
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')
 

--- a/packages/lambda-powertools-firehose-client/package-lock.json
+++ b/packages/lambda-powertools-firehose-client/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "@dazn/lambda-powertools-firehose-client",
-	"version": "1.10.0",
+	"version": "1.11.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"aws-sdk": {
-			"version": "2.517.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.517.0.tgz",
-			"integrity": "sha512-CX0b+8StmzAGQOP5eoBYJExpjTdPeVPig3NC4crq71/0LkrIDGcc6ekVEl0Rx23WTyGDzExeDD1be1HvQNwHdA==",
+			"version": "2.540.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",
+			"integrity": "sha512-CQdXuMED/xPW7y50vObadERIzrVB6Zr87Ln9RIm3VyJuIWUWS92Z7DKAe9F+LdFh1/6zKVd/iLDJ7Fsd/pAEmA==",
 			"requires": {
 				"buffer": "4.9.1",
 				"events": "1.1.1",
-				"ieee754": "1.1.8",
+				"ieee754": "1.1.13",
 				"jmespath": "0.15.0",
 				"querystring": "0.2.0",
 				"sax": "1.2.1",
@@ -41,9 +41,9 @@
 			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"ieee754": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"isarray": {
 			"version": "1.0.0",

--- a/packages/lambda-powertools-firehose-client/package.json
+++ b/packages/lambda-powertools-firehose-client/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
     "@dazn/lambda-powertools-logger": "^1.8.2",
-    "aws-sdk": "^2.246.1"
+    "aws-sdk": "^2.540.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lambda-powertools-kinesis-client/index.js
+++ b/packages/lambda-powertools-kinesis-client/index.js
@@ -1,6 +1,6 @@
 process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
-const AWS = require('aws-sdk')
-const client = new AWS.Kinesis()
+const Kinesis = require('aws-sdk/clients/kinesis')
+const client = new Kinesis()
 const Log = require('@dazn/lambda-powertools-logger')
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')
 

--- a/packages/lambda-powertools-kinesis-client/index.js
+++ b/packages/lambda-powertools-kinesis-client/index.js
@@ -1,3 +1,4 @@
+process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
 const AWS = require('aws-sdk')
 const client = new AWS.Kinesis()
 const Log = require('@dazn/lambda-powertools-logger')

--- a/packages/lambda-powertools-kinesis-client/index.js
+++ b/packages/lambda-powertools-kinesis-client/index.js
@@ -1,18 +1,4 @@
 const AWS = require('aws-sdk')
-const https = require('https')
-const sslAgent = new https.Agent({
-  keepAlive: true,
-  maxSockets: 50,
-  rejectUnauthorized: true
-})
-sslAgent.setMaxListeners(0)
-
-AWS.config.update({
-  httpOptions: {
-    agent: sslAgent
-  }
-})
-
 const client = new AWS.Kinesis()
 const Log = require('@dazn/lambda-powertools-logger')
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')

--- a/packages/lambda-powertools-kinesis-client/package-lock.json
+++ b/packages/lambda-powertools-kinesis-client/package-lock.json
@@ -1,29 +1,29 @@
 {
 	"name": "@dazn/lambda-powertools-kinesis-client",
-	"version": "0.10.0",
+	"version": "1.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"aws-sdk": {
-			"version": "2.247.1",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.247.1.tgz",
-			"integrity": "sha1-vl8iDUBmWskdOoSlHwKfoFVgxO4=",
+			"version": "2.540.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",
+			"integrity": "sha512-CQdXuMED/xPW7y50vObadERIzrVB6Zr87Ln9RIm3VyJuIWUWS92Z7DKAe9F+LdFh1/6zKVd/iLDJ7Fsd/pAEmA==",
 			"requires": {
 				"buffer": "4.9.1",
 				"events": "1.1.1",
-				"ieee754": "1.1.8",
+				"ieee754": "1.1.13",
 				"jmespath": "0.15.0",
 				"querystring": "0.2.0",
 				"sax": "1.2.1",
 				"url": "0.10.3",
-				"uuid": "3.1.0",
-				"xml2js": "0.4.17"
+				"uuid": "3.3.2",
+				"xml2js": "0.4.19"
 			}
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"buffer": {
 			"version": "4.9.1",
@@ -41,9 +41,9 @@
 			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"ieee754": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -54,11 +54,6 @@
 			"version": "0.15.0",
 			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
 			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-		},
-		"lodash": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"punycode": {
 			"version": "1.3.2",
@@ -85,26 +80,23 @@
 			}
 		},
 		"uuid": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"xml2js": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-			"integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
 			"requires": {
 				"sax": ">=0.6.0",
-				"xmlbuilder": "^4.1.0"
+				"xmlbuilder": "~9.0.1"
 			}
 		},
 		"xmlbuilder": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-			"integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-			"requires": {
-				"lodash": "^4.0.0"
-			}
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		}
 	}
 }

--- a/packages/lambda-powertools-kinesis-client/package.json
+++ b/packages/lambda-powertools-kinesis-client/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
     "@dazn/lambda-powertools-logger": "^1.9.0",
-    "aws-sdk": "^2.246.1"
+    "aws-sdk": "^2.540.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lambda-powertools-lambda-client/index.js
+++ b/packages/lambda-powertools-lambda-client/index.js
@@ -1,18 +1,4 @@
 const AWS = require('aws-sdk')
-const https = require('https')
-const sslAgent = new https.Agent({
-  keepAlive: true,
-  maxSockets: 50,
-  rejectUnauthorized: true
-})
-sslAgent.setMaxListeners(0)
-
-AWS.config.update({
-  httpOptions: {
-    agent: sslAgent
-  }
-})
-
 const client = new AWS.Lambda()
 const Log = require('@dazn/lambda-powertools-logger')
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')

--- a/packages/lambda-powertools-lambda-client/index.js
+++ b/packages/lambda-powertools-lambda-client/index.js
@@ -1,3 +1,4 @@
+process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
 const AWS = require('aws-sdk')
 const client = new AWS.Lambda()
 const Log = require('@dazn/lambda-powertools-logger')

--- a/packages/lambda-powertools-lambda-client/index.js
+++ b/packages/lambda-powertools-lambda-client/index.js
@@ -1,6 +1,6 @@
 process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
-const AWS = require('aws-sdk')
-const client = new AWS.Lambda()
+const Lambda = require('aws-sdk/clients/lambda')
+const client = new Lambda()
 const Log = require('@dazn/lambda-powertools-logger')
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')
 

--- a/packages/lambda-powertools-lambda-client/package-lock.json
+++ b/packages/lambda-powertools-lambda-client/package-lock.json
@@ -1,29 +1,29 @@
 {
 	"name": "@dazn/lambda-powertools-lambda-client",
-	"version": "0.10.0",
+	"version": "1.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"aws-sdk": {
-			"version": "2.259.1",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.259.1.tgz",
-			"integrity": "sha512-z2/t30caHNadSKeasUTS8trgIoHuWtmOKEhQK72Bqtbbgviqw2++sDG1Gkbj7n7yRihmg+yPNUE6i+JG3vfDrA==",
+			"version": "2.540.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",
+			"integrity": "sha512-CQdXuMED/xPW7y50vObadERIzrVB6Zr87Ln9RIm3VyJuIWUWS92Z7DKAe9F+LdFh1/6zKVd/iLDJ7Fsd/pAEmA==",
 			"requires": {
 				"buffer": "4.9.1",
 				"events": "1.1.1",
-				"ieee754": "1.1.8",
+				"ieee754": "1.1.13",
 				"jmespath": "0.15.0",
 				"querystring": "0.2.0",
 				"sax": "1.2.1",
 				"url": "0.10.3",
-				"uuid": "3.1.0",
-				"xml2js": "0.4.17"
+				"uuid": "3.3.2",
+				"xml2js": "0.4.19"
 			}
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"buffer": {
 			"version": "4.9.1",
@@ -41,9 +41,9 @@
 			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"ieee754": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -54,11 +54,6 @@
 			"version": "0.15.0",
 			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
 			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-		},
-		"lodash": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"punycode": {
 			"version": "1.3.2",
@@ -85,26 +80,23 @@
 			}
 		},
 		"uuid": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"xml2js": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-			"integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
 			"requires": {
 				"sax": ">=0.6.0",
-				"xmlbuilder": "^4.1.0"
+				"xmlbuilder": "~9.0.1"
 			}
 		},
 		"xmlbuilder": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-			"integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-			"requires": {
-				"lodash": "^4.0.0"
-			}
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		}
 	}
 }

--- a/packages/lambda-powertools-lambda-client/package.json
+++ b/packages/lambda-powertools-lambda-client/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
     "@dazn/lambda-powertools-logger": "^1.9.0",
-    "aws-sdk": "^2.246.1"
+    "aws-sdk": "^2.540.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lambda-powertools-sns-client/index.js
+++ b/packages/lambda-powertools-sns-client/index.js
@@ -1,6 +1,6 @@
 process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
-const AWS = require('aws-sdk')
-const client = new AWS.SNS()
+const SNS = require('aws-sdk/clients/sns')
+const client = new SNS()
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')
 
 function addCorrelationIds (correlationIds, messageAttributes) {

--- a/packages/lambda-powertools-sns-client/index.js
+++ b/packages/lambda-powertools-sns-client/index.js
@@ -1,18 +1,4 @@
 const AWS = require('aws-sdk')
-const https = require('https')
-const sslAgent = new https.Agent({
-  keepAlive: true,
-  maxSockets: 50,
-  rejectUnauthorized: true
-})
-sslAgent.setMaxListeners(0)
-
-AWS.config.update({
-  httpOptions: {
-    agent: sslAgent
-  }
-})
-
 const client = new AWS.SNS()
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')
 

--- a/packages/lambda-powertools-sns-client/index.js
+++ b/packages/lambda-powertools-sns-client/index.js
@@ -1,3 +1,4 @@
+process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
 const AWS = require('aws-sdk')
 const client = new AWS.SNS()
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')

--- a/packages/lambda-powertools-sns-client/package-lock.json
+++ b/packages/lambda-powertools-sns-client/package-lock.json
@@ -1,29 +1,29 @@
 {
   "name": "@dazn/lambda-powertools-sns-client",
-  "version": "0.10.0",
+  "version": "1.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "aws-sdk": {
-      "version": "2.246.1",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.246.1.tgz",
-      "integrity": "sha1-2iTmLmmkqvjFqYrB67rJ0k5gG8k=",
+      "version": "2.540.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",
+      "integrity": "sha512-CQdXuMED/xPW7y50vObadERIzrVB6Zr87Ln9RIm3VyJuIWUWS92Z7DKAe9F+LdFh1/6zKVd/iLDJ7Fsd/pAEmA==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
-        "ieee754": "1.1.8",
+        "ieee754": "1.1.13",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.1.0",
-        "xml2js": "0.4.17"
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
       }
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "buffer": {
       "version": "4.9.1",
@@ -41,9 +41,9 @@
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -54,11 +54,6 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
-    "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "punycode": {
       "version": "1.3.2",
@@ -85,26 +80,23 @@
       }
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "^4.1.0"
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "requires": {
-        "lodash": "^4.0.0"
-      }
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/packages/lambda-powertools-sns-client/package.json
+++ b/packages/lambda-powertools-sns-client/package.json
@@ -10,7 +10,7 @@
   "author": "Yan Cui",
   "dependencies": {
     "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-    "aws-sdk": "^2.246.1"
+    "aws-sdk": "^2.540.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lambda-powertools-sqs-client/index.js
+++ b/packages/lambda-powertools-sqs-client/index.js
@@ -1,6 +1,6 @@
 process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
-const AWS = require('aws-sdk')
-const client = new AWS.SQS()
+const SQS = require('aws-sdk/clients/sqs')
+const client = new SQS()
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')
 
 function addCorrelationIds (correlationIds, messageAttributes) {

--- a/packages/lambda-powertools-sqs-client/index.js
+++ b/packages/lambda-powertools-sqs-client/index.js
@@ -1,3 +1,4 @@
+process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
 const AWS = require('aws-sdk')
 const client = new AWS.SQS()
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')

--- a/packages/lambda-powertools-sqs-client/index.js
+++ b/packages/lambda-powertools-sqs-client/index.js
@@ -1,18 +1,4 @@
 const AWS = require('aws-sdk')
-const https = require('https')
-const sslAgent = new https.Agent({
-  keepAlive: true,
-  maxSockets: 50,
-  rejectUnauthorized: true
-})
-sslAgent.setMaxListeners(0)
-
-AWS.config.update({
-  httpOptions: {
-    agent: sslAgent
-  }
-})
-
 const client = new AWS.SQS()
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')
 

--- a/packages/lambda-powertools-sqs-client/package-lock.json
+++ b/packages/lambda-powertools-sqs-client/package-lock.json
@@ -1,29 +1,29 @@
 {
 	"name": "@dazn/lambda-powertools-sqs-client",
-	"version": "0.10.0",
+	"version": "1.8.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"aws-sdk": {
-			"version": "2.286.2",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.286.2.tgz",
-			"integrity": "sha512-46a/2+rGEgIlmUz08vZOkYFmZIgj+An/cc+Ngz9XBLkAZbx+3sBzOrxexrlVV69MPkMbckbeZjIq8NEJWV5gPw==",
+			"version": "2.540.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",
+			"integrity": "sha512-CQdXuMED/xPW7y50vObadERIzrVB6Zr87Ln9RIm3VyJuIWUWS92Z7DKAe9F+LdFh1/6zKVd/iLDJ7Fsd/pAEmA==",
 			"requires": {
 				"buffer": "4.9.1",
 				"events": "1.1.1",
-				"ieee754": "1.1.8",
+				"ieee754": "1.1.13",
 				"jmespath": "0.15.0",
 				"querystring": "0.2.0",
 				"sax": "1.2.1",
 				"url": "0.10.3",
-				"uuid": "3.1.0",
+				"uuid": "3.3.2",
 				"xml2js": "0.4.19"
 			}
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"buffer": {
 			"version": "4.9.1",
@@ -41,9 +41,9 @@
 			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"ieee754": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -80,9 +80,9 @@
 			}
 		},
 		"uuid": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"xml2js": {
 			"version": "0.4.19",

--- a/packages/lambda-powertools-sqs-client/package.json
+++ b/packages/lambda-powertools-sqs-client/package.json
@@ -10,7 +10,7 @@
   "author": "Yan Cui",
   "dependencies": {
     "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-    "aws-sdk": "^2.246.1"
+    "aws-sdk": "^2.540.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lambda-powertools-step-functions-client/index.js
+++ b/packages/lambda-powertools-step-functions-client/index.js
@@ -1,6 +1,6 @@
 process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
-const AWS = require('aws-sdk')
-const client = new AWS.StepFunctions()
+const StepFunctions = require('aws-sdk/clients/stepfunctions')
+const client = new StepFunctions()
 const Log = require('@dazn/lambda-powertools-logger')
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')
 

--- a/packages/lambda-powertools-step-functions-client/index.js
+++ b/packages/lambda-powertools-step-functions-client/index.js
@@ -1,18 +1,4 @@
 const AWS = require('aws-sdk')
-const https = require('https')
-const sslAgent = new https.Agent({
-  keepAlive: true,
-  maxSockets: 50,
-  rejectUnauthorized: true
-})
-sslAgent.setMaxListeners(0)
-
-AWS.config.update({
-  httpOptions: {
-    agent: sslAgent
-  }
-})
-
 const client = new AWS.StepFunctions()
 const Log = require('@dazn/lambda-powertools-logger')
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')

--- a/packages/lambda-powertools-step-functions-client/index.js
+++ b/packages/lambda-powertools-step-functions-client/index.js
@@ -1,3 +1,4 @@
+process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
 const AWS = require('aws-sdk')
 const client = new AWS.StepFunctions()
 const Log = require('@dazn/lambda-powertools-logger')

--- a/packages/lambda-powertools-step-functions-client/package-lock.json
+++ b/packages/lambda-powertools-step-functions-client/package-lock.json
@@ -1,29 +1,29 @@
 {
 	"name": "@dazn/lambda-powertools-step-functions-client",
-	"version": "0.10.0",
+	"version": "1.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"aws-sdk": {
-			"version": "2.259.1",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.259.1.tgz",
-			"integrity": "sha512-z2/t30caHNadSKeasUTS8trgIoHuWtmOKEhQK72Bqtbbgviqw2++sDG1Gkbj7n7yRihmg+yPNUE6i+JG3vfDrA==",
+			"version": "2.540.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",
+			"integrity": "sha512-CQdXuMED/xPW7y50vObadERIzrVB6Zr87Ln9RIm3VyJuIWUWS92Z7DKAe9F+LdFh1/6zKVd/iLDJ7Fsd/pAEmA==",
 			"requires": {
 				"buffer": "4.9.1",
 				"events": "1.1.1",
-				"ieee754": "1.1.8",
+				"ieee754": "1.1.13",
 				"jmespath": "0.15.0",
 				"querystring": "0.2.0",
 				"sax": "1.2.1",
 				"url": "0.10.3",
-				"uuid": "3.1.0",
-				"xml2js": "0.4.17"
+				"uuid": "3.3.2",
+				"xml2js": "0.4.19"
 			}
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"buffer": {
 			"version": "4.9.1",
@@ -41,9 +41,9 @@
 			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"ieee754": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -54,11 +54,6 @@
 			"version": "0.15.0",
 			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
 			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-		},
-		"lodash": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"punycode": {
 			"version": "1.3.2",
@@ -85,26 +80,23 @@
 			}
 		},
 		"uuid": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"xml2js": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-			"integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
 			"requires": {
 				"sax": ">=0.6.0",
-				"xmlbuilder": "^4.1.0"
+				"xmlbuilder": "~9.0.1"
 			}
 		},
 		"xmlbuilder": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-			"integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-			"requires": {
-				"lodash": "^4.0.0"
-			}
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		}
 	}
 }

--- a/packages/lambda-powertools-step-functions-client/package.json
+++ b/packages/lambda-powertools-step-functions-client/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
     "@dazn/lambda-powertools-logger": "^1.9.0",
-    "aws-sdk": "^2.246.1"
+    "aws-sdk": "^2.540.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #89

Enable HTTP keepalive in the AWS SDK using env vars instead now that it's supported natively.

## How did you implement it:

Remove the custom HTTP agent code, and instead set the env var `AWS_NODEJS_CONNECTION_REUSE_ENABLED` to 1. And made sure we're on the latest AWS SDK as well.

## Todos:

- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
