### PR TITLE
Override DATADOG_PREFIX only if it is not defined

### DIFF
--- a/packages/lambda-powertools-pattern-basic/__tests__/index.js
+++ b/packages/lambda-powertools-pattern-basic/__tests__/index.js
@@ -52,4 +52,30 @@ describe('basic pattern', () => {
       expect(SampleLogging).toHaveBeenCalledWith({ sampleRate: 0.03 })
     })
   })
+
+  describe('override DATADOG_PREFIX if not defined', () => {
+    const funcName = 'lambda-powertools-func'
+
+    beforeAll(() => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = funcName
+      delete process.env.DATADOG_PREFIX
+      jest.resetModules()
+    })
+
+    afterAll(() => {
+      delete process.env.DATADOG_PREFIX
+      delete process.env.AWS_LAMBDA_FUNCTION_NAME
+    })
+
+    it('should override DATADOG_PREFIX not defined', () => {
+      require('../index')
+      expect(process.env.DATADOG_PREFIX).toBe(funcName + '.')
+    })
+
+    it('should NOT override DATADOG_PREFIX if defined', () => {
+      process.env.DATADOG_PREFIX = ''
+      require('../index')
+      expect(process.env.DATADOG_PREFIX).toStrictEqual('')
+    })
+  })
 })

--- a/packages/lambda-powertools-pattern-basic/index.js
+++ b/packages/lambda-powertools-pattern-basic/index.js
@@ -9,7 +9,7 @@ const FUNCTION_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME
 const FUNCTION_VERSION = process.env.AWS_LAMBDA_FUNCTION_VERSION
 const ENV = process.env.ENVIRONMENT || process.env.STAGE
 
-if (!process.env.DATADOG_PREFIX) {
+if (process.env.DATADOG_PREFIX === undefined) {
   process.env.DATADOG_PREFIX = FUNCTION_NAME + '.'
 }
 

--- a/packages/lambda-powertools-pattern-obfuscate/__tests__/index.js
+++ b/packages/lambda-powertools-pattern-obfuscate/__tests__/index.js
@@ -81,4 +81,30 @@ describe('obfuscate pattern', () => {
       process.env = OLD_ENV
     })
   })
+
+  describe('override DATADOG_PREFIX if not defined', () => {
+    const funcName = 'lambda-powertools-func'
+
+    beforeAll(() => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = funcName
+      delete process.env.DATADOG_PREFIX
+      jest.resetModules()
+    })
+
+    afterAll(() => {
+      delete process.env.DATADOG_PREFIX
+      delete process.env.AWS_LAMBDA_FUNCTION_NAME
+    })
+
+    it('should override DATADOG_PREFIX not defined', () => {
+      require('../index')
+      expect(process.env.DATADOG_PREFIX).toBe(funcName + '.')
+    })
+
+    it('should NOT override DATADOG_PREFIX if defined', () => {
+      process.env.DATADOG_PREFIX = ''
+      require('../index')
+      expect(process.env.DATADOG_PREFIX).toStrictEqual('')
+    })
+  })
 })

--- a/packages/lambda-powertools-pattern-obfuscate/index.js
+++ b/packages/lambda-powertools-pattern-obfuscate/index.js
@@ -16,7 +16,7 @@ const ENV = process.env.ENVIRONMENT || process.env.STAGE
  */
 const FILTERING_MODE = Object.freeze({ 'BLACKLIST': 'BLACKLIST', 'WHITELIST': 'WHITELIST' })
 
-if (!process.env.DATADOG_PREFIX) {
+if (process.env.DATADOG_PREFIX === undefined) {
   process.env.DATADOG_PREFIX = FUNCTION_NAME + '.'
 }
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Changed the behavior that overrides `DATADOG_PREFIX` if it is undefined or
empty.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Override only if it is `undefined`.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

The tests illustrate the new behavior.

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / projects / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES