### PR TITLE
feat: handle cases when context is undefined

### DIFF
--- a/packages/lambda-powertools-middleware-sample-logging/__tests__/index.js
+++ b/packages/lambda-powertools-middleware-sample-logging/__tests__/index.js
@@ -89,4 +89,20 @@ describe('Sample logging middleware', () => {
       })
     })
   })
+
+  // it's common for test code to omit context, see #133
+  describe('when context is missing', () => {
+    it('should not error in the onError handler', async () => {
+      const handler = middy((event, context, cb) => {
+        throw new Error('boom')
+      })
+      handler.use(sampleLogMiddleware({ sampleRate: 1 }))
+      handler({}, undefined, () => {})
+      errorLogWasWritten(x => {
+        expect(x.errorName).toBe('Error')
+        expect(x.errorMessage).toBe('boom')
+        expect(x.awsRequestId).toBe('')
+      })
+    })
+  })
 })

--- a/packages/lambda-powertools-middleware-sample-logging/index.js
+++ b/packages/lambda-powertools-middleware-sample-logging/index.js
@@ -28,8 +28,8 @@ module.exports = ({ sampleRate }) => {
       next()
     },
     onError: (handler, next) => {
-      let awsRequestId = handler.context.awsRequestId
-      let invocationEvent = JSON.stringify(handler.event)
+      const awsRequestId = handler.context ? handler.context.awsRequestId : ''
+      const invocationEvent = JSON.stringify(handler.event)
       Log.error('invocation failed', { awsRequestId, invocationEvent }, handler.error)
 
       next(handler.error)


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #133

<!--
Briefly describe the feature if no issue exists for this PR
-->

The sample logging middleware's `onError` handler tolerates when `context` is omitted, which is often the case in test code.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
