### PR TITLE
fix(http-client): honor custom metricName option when passed in

### DIFF
--- a/packages/lambda-powertools-http-client/index.js
+++ b/packages/lambda-powertools-http-client/index.js
@@ -97,7 +97,7 @@ const Req = (options) => {
 
   const start = Date.now()
   const url = new URL.URL(options.uri)
-  const metricName = options.methicName || url.hostname + '.response'
+  const metricName = options.metricName || url.hostname + '.response'
   const requestMetricTags = [
     `method:${method}`,
     `path:${url.pathname}`


### PR DESCRIPTION
## What did you implement:

Closes #138

## How did you implement it:

Noticed that the `metricName` option was being ignored and found a typo when pulling trying to pull the metricName from the options [here](https://github.com/getndazn/dazn-lambda-powertools/blob/master/packages/lambda-powertools-http-client/index.js#L100) which causes the url.hostname to always be used instead. Wrote tests to verify the same behavior we've been seeing in our implementation and then fixed the typo to make those tests go green.

## How can we verify it:

I've already wrote tests to verify this in the metrics.js, but can be easily verified by passing in the `metricName` option when using the http-client and verify that the prefix actually gets used in the outputted histogram and count metrics that are generated from the response.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / projects / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
