### PR TITLE
feat(http-client): add support for patch and url option

### DIFF
--- a/packages/lambda-powertools-http-client/README.md
+++ b/packages/lambda-powertools-http-client/README.md
@@ -48,8 +48,8 @@ It's essentially a function that accepts a request of type:
 
 ```js
 {
-  uri     : string
-  method  : GET (default) | POST | PUT | HEAD
+  uri/url : string (either uri or url must be specified)
+  method  : GET (default) | POST | PUT | HEAD | DELETE | PATCH
   headers : object
   qs      : object
   body    : object

--- a/packages/lambda-powertools-http-client/__tests__/request.js
+++ b/packages/lambda-powertools-http-client/__tests__/request.js
@@ -1,0 +1,68 @@
+const nock = require('nock')
+
+// spy on https.request to see when it's actually called
+const http = require('https')
+const mockRequest = jest.spyOn(http, 'request')
+
+global.console.log = jest.fn()
+
+const Req = require('../index')
+const url = 'https://theburningmonk.com'
+const host = 'theburningmonk.com:443'
+
+beforeEach(mockRequest.mockClear)
+
+afterAll(mockRequest.mockRestore)
+
+const verifyRequestMethod = async (method, f) => {
+  f()
+
+  await Req({
+    uri: url,
+    method: method,
+    headers: {}
+  })
+
+  expect(mockRequest).toBeCalled()
+
+  const methodToCall = mockRequest.mock.calls[0][0].method
+  expect(methodToCall).toEqual(method)
+}
+
+const verifyRequestUri = async (option) => {
+  nock(url).get('/').reply(200)
+
+  const options = {
+    method: 'GET',
+    headers: {}
+  }
+  options[option] = url
+  await Req(options)
+
+  expect(mockRequest).toBeCalled()
+
+  const hostCalled = mockRequest.mock.calls[0][0].host
+  expect(hostCalled).toEqual(host)
+}
+
+describe('HTTP client (request)', () => {
+  it.each([
+    'GET',
+    'HEAD',
+    'POST',
+    'PUT',
+    'DELETE',
+    'PATCH'
+  ])('calls %s method correctly', async (method) => {
+    await verifyRequestMethod(method, f => {
+      nock(url)[method.toLowerCase()]('/').reply(200)
+    })
+  })
+
+  it.each([
+    'uri',
+    'url'
+  ])('calls request with %s option correctly', async (option) => {
+    await verifyRequestUri(option)
+  })
+})

--- a/packages/lambda-powertools-http-client/index.js
+++ b/packages/lambda-powertools-http-client/index.js
@@ -26,6 +26,8 @@ function getRequest (uri, method) {
       return HTTP.put(uri)
     case 'delete':
       return HTTP.del(uri)
+    case 'patch':
+      return HTTP.patch(uri)
     default:
       throw new Error(`unsupported method : ${method.toLowerCase()}`)
   }
@@ -60,8 +62,8 @@ function setBody (request, body) {
 }
 
 // options: {
-//    uri     : string
-//    method  : GET (default) | POST | PUT | HEAD
+//    uri/url : string (either uri or url must be specified)
+//    method  : GET (default) | POST | PUT | HEAD | DELETE | PATCH
 //    headers : object
 //    qs      : object
 //    body    : object
@@ -75,8 +77,9 @@ const Req = (options) => {
     throw new Error('no HTTP request options is provided')
   }
 
-  if (!options.uri) {
-    throw new Error('no HTTP uri is specified')
+  const uri = options.uri || options.url
+  if (!uri) {
+    throw new Error('no HTTP uri or url is specified')
   }
 
   const correlationIds = (options.correlationIds || CorrelationIds).get()
@@ -85,7 +88,7 @@ const Req = (options) => {
   let headers = Object.assign({}, correlationIds, options.headers)
 
   const method = options.method || 'get'
-  let request = getRequest(options.uri, method)
+  let request = getRequest(uri, method)
 
   request = setHeaders(request, headers)
   request = setQueryStrings(request, options.qs)
@@ -96,7 +99,7 @@ const Req = (options) => {
   }
 
   const start = Date.now()
-  const url = new URL.URL(options.uri)
+  const url = new URL.URL(uri)
   const metricName = options.metricName || url.hostname + '.response'
   const requestMetricTags = [
     `method:${method}`,


### PR DESCRIPTION
## What did you implement:

Closes #140 and #141

## How did you implement it:

Modified http client to support PATCH method and pass through properly to superagent since it currently already supports PATCH.

Modified http client options to allow `url` to be used as an option if `uri` isn't present to assist in migration and adoption from other clients.

I can split this into multiple PRs if desired, but both of these features were 2 of biggest issues we kept running into when switching our services over to use the dazn http client, so I addressed them together since both changes were quite small.

## How can we verify it:

I wrote tests for both of these in the request.js file to make sure that all http methods get called as expected and both the uri/url options are being used properly.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / projects / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
