### PR TITLE
feat(sample logging middleware)

### DIFF
--- a/packages/lambda-powertools-middleware-sample-logging/index.js
+++ b/packages/lambda-powertools-middleware-sample-logging/index.js
@@ -28,9 +28,11 @@ module.exports = ({ sampleRate }) => {
       next()
     },
     onError: (handler, next) => {
-      const awsRequestId = handler.context ? handler.context.awsRequestId : ''
-      const invocationEvent = JSON.stringify(handler.event)
-      Log.error('invocation failed', { awsRequestId, invocationEvent }, handler.error)
+      if (process.env.POWERTOOLS_IGNORE_ERRORS !== 'true') {
+        const awsRequestId = handler.context ? handler.context.awsRequestId : ''
+        const invocationEvent = JSON.stringify(handler.event)
+        Log.error('invocation failed', { awsRequestId, invocationEvent }, handler.error)
+      }
 
       next(handler.error)
     }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

I allowed users to have the choice if their uncaught errors are to be logged. This allows people to send validation errors to appsync or step functions without being logged out as errors.
https://github.com/getndazn/dazn-lambda-powertools/issues/145

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
I added an enviroment variable ( POWERTOOLS_IGNORE_ERRORS ) following a proposed standard from https://github.com/getndazn/dazn-lambda-powertools/issues/53. to give people the choice if they want there uncaught errors to be logged.


<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Have a lambda function return an error wrapped with sample logging middleware. Ensure that when enviroment variable POWERTOOLS_IGNORE_ERRORS  = true then it doesn't log errors sent back. Also when POWERTOOLS_IGNORE_ERRORS is anything else that it logs the errors.
<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / projects / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
