### PR TITLE
feat: made aws-sdk dev dep in correlation ids pkg

### DIFF
--- a/packages/lambda-powertools-cloudwatchevents-client/package-lock.json
+++ b/packages/lambda-powertools-cloudwatchevents-client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dazn/lambda-powertools-cloudwatchevents-client",
-	"version": "1.15.6",
+	"version": "1.18.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/lambda-powertools-eventbridge-client/package-lock.json
+++ b/packages/lambda-powertools-eventbridge-client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dazn/lambda-powertools-eventbridge-client",
-	"version": "1.15.6",
+	"version": "1.18.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/lambda-powertools-lambda-client/index.js
+++ b/packages/lambda-powertools-lambda-client/index.js
@@ -1,7 +1,7 @@
 process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1'
 const Lambda = require('aws-sdk/clients/lambda')
 const client = new Lambda({
-  endpoint: process.env.IS_OFFLINE ? 'http://localhost:3000' : undefined,
+  endpoint: process.env.IS_OFFLINE ? 'http://localhost:3000' : undefined
 })
 const Log = require('@dazn/lambda-powertools-logger')
 const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')

--- a/packages/lambda-powertools-middleware-correlation-ids/package.json
+++ b/packages/lambda-powertools-middleware-correlation-ids/package.json
@@ -10,10 +10,10 @@
   "author": "Yan Cui",
   "dependencies": {
     "@dazn/lambda-powertools-correlation-ids": "^1.5.0",
-    "@dazn/lambda-powertools-logger": "^1.15.2",
-    "aws-sdk": "^2.496.0"
+    "@dazn/lambda-powertools-logger": "^1.15.2"    
   },
   "devDependencies": {
+    "aws-sdk": "^2.496.0",
     "lodash": "^4.17.11",
     "middy": "^0.15.6",
     "uuid": "^3.2.1"


### PR DESCRIPTION
## What did you implement:

Closes #149 

The AWS SDK dependency is now a dev dependency only for the correlation IDs middleware to avoid bloating.

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
