### PR TITLE
build: make deleting docs branch optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - image: circleci/node:10.15
     steps:
       - *ATTACH_WORKSPACE
-      - run: git branch -D gh-pages
+      - run: git branch -D gh-pages || true
       - run: npm run docs
       - run: git add .
       - run: "git commit -m 'chore: temp deploy docs commit'"


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

The docs on master are failing as the [CI tries to delete the `gh-pages` branch](https://circleci.com/gh/getndazn/dazn-lambda-powertools/1118) but cannot since it doesn't exist. This PR makes the step optional to prevent the build from failing. 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

As above. 

## How can we verify it:

Merge to master! 

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / projects / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
