### PR TITLE
ci(circleci): skip ci when running new lerna version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:lint": "eslint .",
     "test": "lerna run --concurrency 1 test -- -- --config=../../jest.config.js",
     "diff": "lerna diff",
-    "new-version": "lerna version --conventional-commits --github-release --yes",
+    "new-version": "lerna version --conventional-commits --github-release --yes -m \"chore(release): %v [ci skip]\"",
     "publish": "lerna publish from-package --yes",
     "lerna": "lerna",
     "docs": "gitbook build . docs"


### PR DESCRIPTION
* Skip CI when tagged releases are pushed by lerna as no changes are made to publish but build still fails due to updated package lock files.