### PR TITLE
chore: update lerna version command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:lint": "eslint .",
     "test": "lerna run --concurrency 1 test -- -- --config=../../jest.config.js",
     "diff": "lerna diff",
-    "new-version": "lerna version --conventional-commits --github-release --yes -m \"chore(release): %v [ci skip]\"",
+    "new-version": "lerna version --conventional-commits --create-release=github --yes -m \"chore(release): %v [ci skip]\"",
     "publish": "lerna publish from-package --yes",
     "lerna": "lerna",
     "docs": "gitbook build . docs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:lint": "eslint .",
     "test": "lerna run --concurrency 1 test -- -- --config=../../jest.config.js",
     "diff": "lerna diff",
-    "new-version": "lerna version --conventional-commits --create-release=github --yes -m \"chore(release): %v [ci skip]\"",
+    "new-version": "lerna version --conventional-commits --create-release github --yes -m \"chore(release): %v [ci skip]\"",
     "publish": "lerna publish from-package --yes",
     "lerna": "lerna",
     "docs": "gitbook build . docs"


### PR DESCRIPTION
* Remove deprecated version arg when performing `lerna version` - `WARN deprecated --github-release has been replaced by --create-release=github`