### PR TITLE
build(deps): install all deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,7 @@ jobs:
     steps:
       - checkout
       - run: npm ci
-      - run: npm run install
-
+      - run: npm run bootstrap:ci
       - *PERSIST_TO_WORKSPACE
   test-node12:
     docker:

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -12,17 +12,83 @@
         "datadog-metrics": "0.8.1"
       }
     },
+    "@dazn/lambda-powertools-cloudwatchevents-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-cloudwatchevents-client/-/lambda-powertools-cloudwatchevents-client-1.23.0.tgz",
+      "integrity": "sha1-y5qSgpYXPKqqfO6UChKUMxhCj08=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0",
+        "aws-sdk": "2.658.0"
+      }
+    },
     "@dazn/lambda-powertools-correlation-ids": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.8.2.tgz",
-      "integrity": "sha512-zZvahepZI7vC3qvT+z0eVXbt9gJ6vHK0UJcw2IZ5EOhocYfOJhNsaGIv6HdOp8nDGAQkVLH8IY3Ih/wLoBU4Lg=="
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+    },
+    "@dazn/lambda-powertools-dynamodb-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-dynamodb-client/-/lambda-powertools-dynamodb-client-1.23.0.tgz",
+      "integrity": "sha1-auugwdlj0TJ98krQoctNUmxeXpw=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "lodash.chunk": "4.2.0"
+      }
+    },
+    "@dazn/lambda-powertools-eventbridge-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-eventbridge-client/-/lambda-powertools-eventbridge-client-1.23.0.tgz",
+      "integrity": "sha1-A60nLuodLVpZQ3fHI17yhM9KBwg=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-firehose-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-firehose-client/-/lambda-powertools-firehose-client-1.23.0.tgz",
+      "integrity": "sha1-1+LUYr/+0/XLdj6ir/mKTcCWjyk=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-http-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-http-client/-/lambda-powertools-http-client-1.23.0.tgz",
+      "integrity": "sha1-3kOhaLovFTlZwgqrXueUDHklVAM=",
+      "requires": {
+        "@dazn/datadog-metrics": "1.3.1",
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "superagent": "3.8.3",
+        "superagent-promise": "1.1.0"
+      }
+    },
+    "@dazn/lambda-powertools-kinesis-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-kinesis-client/-/lambda-powertools-kinesis-client-1.23.0.tgz",
+      "integrity": "sha1-jJGo2ZADVI5+NCuTrZJj/EpRsko=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-lambda-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-lambda-client/-/lambda-powertools-lambda-client-1.23.0.tgz",
+      "integrity": "sha1-SwpWs1fS0Pqh7+1GnPhUbG6Sp7Q=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
     },
     "@dazn/lambda-powertools-logger": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.9.0.tgz",
-      "integrity": "sha512-EN3pxPVWVxn3sr3j/Gfn72A/H8Af8RLyj3FcsSw4kDptG/s46vWP/EYUwecOO02OqX7G+OEObG7AI8+QEgWvCA==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+      "integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "1.8.2"
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-middleware-correlation-ids": {
@@ -30,8 +96,64 @@
       "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-correlation-ids/-/lambda-powertools-middleware-correlation-ids-1.8.3.tgz",
       "integrity": "sha512-FB5jNTxGdZ4PKKElenYO7JnAo/huo2soxLyZt82D8EPrWYwBm4qa6XWZq/P49ifIK17GkxtZndRbewAasHKHzg==",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "1.8.2",
-        "@dazn/lambda-powertools-logger": "1.9.0"
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-log-timeout": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-log-timeout/-/lambda-powertools-middleware-log-timeout-1.23.0.tgz",
+      "integrity": "sha1-vRmwkbD9cYP/9NpBBf159zwTCzo=",
+      "requires": {
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-sample-logging": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-sample-logging/-/lambda-powertools-middleware-sample-logging-1.23.0.tgz",
+      "integrity": "sha1-przT9S7BOGZF6OvPC0/u8a+telk=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-pattern-basic": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-pattern-basic/-/lambda-powertools-pattern-basic-1.23.0.tgz",
+      "integrity": "sha1-7qww1d4YyqNUG9f6T88ToxLbj34=",
+      "requires": {
+        "@dazn/lambda-powertools-middleware-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-middleware-log-timeout": "1.23.0",
+        "@dazn/lambda-powertools-middleware-sample-logging": "1.23.0",
+        "middy": "0.15.10"
+      },
+      "dependencies": {
+        "@dazn/lambda-powertools-middleware-correlation-ids": {
+          "version": "1.23.0",
+          "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-correlation-ids/-/lambda-powertools-middleware-correlation-ids-1.23.0.tgz",
+          "integrity": "sha1-zZ2GEk87BGIlpCr5KLu5ooPCzOM=",
+          "requires": {
+            "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+            "@dazn/lambda-powertools-logger": "1.23.0"
+          }
+        }
+      }
+    },
+    "@dazn/lambda-powertools-sns-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-sns-client/-/lambda-powertools-sns-client-1.23.0.tgz",
+      "integrity": "sha1-CtXZQoMumbvN30Ih/COvnNXqWQw=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-step-functions-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-step-functions-client/-/lambda-powertools-step-functions-client-1.23.0.tgz",
+      "integrity": "sha1-PQvn70YfA/nwVIJFUQ4A2fGTNJk=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@hapi/address": {
@@ -402,6 +524,16 @@
         "defer-to-connect": "1.0.2"
       }
     },
+    "@types/aws-lambda": {
+      "version": "8.10.50",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.50.tgz",
+      "integrity": "sha512-RDzmQ5mO1f0BViKiuOudENZmoCACEa461nTRVtxhsAiEqGCgwdhCYN0aFgk42X5+ELAiqJKbv2mK0LkopYRYQg=="
+    },
+    "@types/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-4KCE/agIcoQ9bIfa4sBxbZdnORzRjIw8JNQPLfqoNv7wQl/8f8mRbW68Q8wBsQFoJkPUHGlQYZ9sqi5WpfGSEQ=="
+    },
     "@types/lodash": {
       "version": "4.14.137",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.137.tgz",
@@ -431,13 +563,22 @@
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "2.0.1",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.4.1",
         "uri-js": "4.2.2"
       }
+    },
+    "ajv-i18n": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-3.5.0.tgz",
+      "integrity": "sha512-IR8uhRH0La4DweKHqBOVeoNo2prJ3bowWzGtNS3uDvYv5wKLgH/WQsoh6gHPVxTWXCGr+R+6I5vXDSXGAYnNPA=="
+    },
+    "ajv-keywords": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
     },
     "ansi": {
       "version": "0.3.1",
@@ -567,14 +708,41 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "aws-sdk": {
+      "version": "2.658.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.658.0.tgz",
+      "integrity": "sha512-vb+CorOG2lod4ZztrVaE3hcSjTwnB9HhTOnD/2R9YJtIUGTJqL0CIDTwo0Q384GFROtDhp7j6SX7oKFwdzDEuA==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -640,8 +808,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "bignumber.js": {
       "version": "1.1.1",
@@ -772,7 +939,6 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
       "requires": {
         "base64-js": "1.3.0",
         "ieee754": "1.1.8",
@@ -1023,7 +1189,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -1037,8 +1202,7 @@
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "compress-commons": {
       "version": "1.2.2",
@@ -1123,8 +1287,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
       "version": "0.4.0",
@@ -1141,8 +1304,7 @@
     "cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-      "dev": true
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -1153,8 +1315,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crc": {
       "version": "3.8.0",
@@ -1467,8 +1628,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -1479,8 +1639,7 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
@@ -1772,8 +1931,7 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "dev": true
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "execa": {
       "version": "0.7.0",
@@ -1893,14 +2051,12 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2018,7 +2174,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
       "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
-      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.8",
@@ -2028,8 +2183,7 @@
     "formidable": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
-      "dev": true
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -2284,7 +2438,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
       "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-      "dev": true,
       "requires": {
         "depd": "1.1.2",
         "inherits": "2.0.4",
@@ -2315,8 +2468,7 @@
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-      "dev": true
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
       "version": "5.1.4",
@@ -2355,8 +2507,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -2654,8 +2805,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -2698,8 +2848,7 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
-      "dev": true
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -2739,6 +2888,11 @@
       "integrity": "sha512-FD/SedD78LCdSvJaOUQAXseT8oQBb5z6IVYaQaCrVUlu9zOAr1BDdKyVYQaSD/GDsAMrXpKcOyBD4LIl8nfjHw==",
       "dev": true
     },
+    "json-mask": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/json-mask/-/json-mask-0.3.9.tgz",
+      "integrity": "sha512-RRu7bf7vzOohKMrU5pD9+fROMltTegWj2trZlPNr7hXekptFGkOZo4S63Jdx2X1GR7IK6rEVvXkQKY+2TPs0PA=="
+    },
     "json-refs": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.7.tgz",
@@ -2774,8 +2928,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -2967,6 +3120,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
+    },
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
@@ -3064,26 +3222,41 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "middy": {
+      "version": "0.15.10",
+      "resolved": "https://registry.npmjs.org/middy/-/middy-0.15.10.tgz",
+      "integrity": "sha1-RbBik/LxcgTXTYeJS6TrbhyDuVI=",
+      "requires": {
+        "@types/aws-lambda": "8.10.50",
+        "@types/http-errors": "1.6.3",
+        "ajv": "6.10.2",
+        "ajv-i18n": "3.5.0",
+        "ajv-keywords": "3.4.1",
+        "content-type": "1.0.4",
+        "http-errors": "1.7.3",
+        "json-mask": "0.3.9",
+        "negotiator": "0.6.2",
+        "once": "1.4.0",
+        "qs": "6.7.0",
+        "querystring": "0.2.0"
+      }
     },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-      "dev": true
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.40.0"
       }
@@ -3226,8 +3399,7 @@
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-      "dev": true
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "next-tick": {
       "version": "1.0.0",
@@ -3387,7 +3559,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -3575,8 +3746,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise-queue": {
       "version": "2.2.5",
@@ -3619,20 +3789,17 @@
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-      "dev": true
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "ramda": {
       "version": "0.26.1",
@@ -3721,7 +3888,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.4",
@@ -3846,8 +4012,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -3867,8 +4032,7 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
-      "dev": true
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "seek-bzip": {
       "version": "1.0.5",
@@ -4266,8 +4430,7 @@
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-      "dev": true
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -4465,14 +4628,12 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -4546,7 +4707,6 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
       "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-      "dev": true,
       "requires": {
         "component-emitter": "1.3.0",
         "cookiejar": "2.1.2",
@@ -4559,6 +4719,11 @@
         "qs": "6.7.0",
         "readable-stream": "2.3.6"
       }
+    },
+    "superagent-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/superagent-promise/-/superagent-promise-1.1.0.tgz",
+      "integrity": "sha1-uvIti73UOamwfdEPjAj1T+JQNTM="
     },
     "supports-color": {
       "version": "2.0.0",
@@ -4804,8 +4969,7 @@
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "dev": true
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "traverse": {
       "version": "0.6.6",
@@ -5040,7 +5204,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "2.1.1"
       },
@@ -5048,8 +5211,7 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "dev": true
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
     },
@@ -5063,7 +5225,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -5093,8 +5254,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -5152,8 +5312,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.4.3",
@@ -5171,6 +5330,20 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.1",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.2",

--- a/layer/nodejs/package-lock.json
+++ b/layer/nodejs/package-lock.json
@@ -9,271 +9,159 @@
       "resolved": "https://registry.npmjs.org/@dazn/datadog-metrics/-/datadog-metrics-1.5.0.tgz",
       "integrity": "sha512-KKuV3fedJD+FyCzq9+Rcnbt+6gD8P+Ma3PLENsSIGlWzkaEaCR2iRSkh8DCcO7xTbrYF8YAPnpojipNgfzYxZQ==",
       "requires": {
-        "datadog-metrics": "^0.8.1"
+        "datadog-metrics": "0.8.1"
       }
     },
     "@dazn/lambda-powertools-correlation-ids": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.8.2.tgz",
-      "integrity": "sha512-zZvahepZI7vC3qvT+z0eVXbt9gJ6vHK0UJcw2IZ5EOhocYfOJhNsaGIv6HdOp8nDGAQkVLH8IY3Ih/wLoBU4Lg=="
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+    },
+    "@dazn/lambda-powertools-dynamodb-client": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-dynamodb-client/-/lambda-powertools-dynamodb-client-1.23.0.tgz",
+      "integrity": "sha1-auugwdlj0TJ98krQoctNUmxeXpw=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "lodash.chunk": "4.2.0"
+      }
     },
     "@dazn/lambda-powertools-firehose-client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-firehose-client/-/lambda-powertools-firehose-client-1.12.0.tgz",
-      "integrity": "sha512-FAgxEEz4FjXbwgQ/72tnJ3esjhE5f/OZ2bt6EORo+0nSfi019TVfIufd12BFs9wF4i6BlWz2fDconI8xkRu7Tg==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-firehose-client/-/lambda-powertools-firehose-client-1.23.0.tgz",
+      "integrity": "sha1-1+LUYr/+0/XLdj6ir/mKTcCWjyk=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "@dazn/lambda-powertools-logger": "^1.8.2",
-        "aws-sdk": "^2.540.0"
-      },
-      "dependencies": {
-        "aws-sdk": {
-          "version": "2.545.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.545.0.tgz",
-          "integrity": "sha512-oQjpvvTkh2a7CvWhSUcFQWkpfkM3wVpzvLgGMInoZ6QIOsuQ+oNKz+zq48yQ619/GP8XnOh0zBQJLcYaa3XAKw==",
-          "requires": {
-            "buffer": "4.9.1",
-            "events": "1.1.1",
-            "ieee754": "1.1.13",
-            "jmespath": "0.15.0",
-            "querystring": "0.2.0",
-            "sax": "1.2.1",
-            "url": "0.10.3",
-            "uuid": "3.3.2",
-            "xml2js": "0.4.19"
-          }
-        },
-        "ieee754": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-        }
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-http-client": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-http-client/-/lambda-powertools-http-client-1.8.2.tgz",
-      "integrity": "sha512-7VawmxiZ2h/onugS73xeTRB6DJkkwrsnVatmfTIvXErnPmN/2BobEoPJYmzW0/Ew3dUqkMjAStMLaU4x3dFnQA==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-http-client/-/lambda-powertools-http-client-1.23.0.tgz",
+      "integrity": "sha1-3kOhaLovFTlZwgqrXueUDHklVAM=",
       "requires": {
-        "@dazn/datadog-metrics": "^1.3.1",
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "superagent": "^3.8.3",
-        "superagent-promise": "^1.1.0"
+        "@dazn/datadog-metrics": "1.5.0",
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "superagent": "3.8.3",
+        "superagent-promise": "1.1.0"
       }
     },
     "@dazn/lambda-powertools-kinesis-client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-kinesis-client/-/lambda-powertools-kinesis-client-1.12.0.tgz",
-      "integrity": "sha512-fbH21waXLu9hm4Y2MhK0JuaUJhlYzyLtg97yQmFto711FafAFNiCY4J8u6Y0XQZuFNN6ukA3tET2T6Giei9H6w==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-kinesis-client/-/lambda-powertools-kinesis-client-1.23.0.tgz",
+      "integrity": "sha1-jJGo2ZADVI5+NCuTrZJj/EpRsko=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "@dazn/lambda-powertools-logger": "^1.9.0",
-        "aws-sdk": "^2.540.0"
-      },
-      "dependencies": {
-        "aws-sdk": {
-          "version": "2.545.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.545.0.tgz",
-          "integrity": "sha512-oQjpvvTkh2a7CvWhSUcFQWkpfkM3wVpzvLgGMInoZ6QIOsuQ+oNKz+zq48yQ619/GP8XnOh0zBQJLcYaa3XAKw==",
-          "requires": {
-            "buffer": "4.9.1",
-            "events": "1.1.1",
-            "ieee754": "1.1.13",
-            "jmespath": "0.15.0",
-            "querystring": "0.2.0",
-            "sax": "1.2.1",
-            "url": "0.10.3",
-            "uuid": "3.3.2",
-            "xml2js": "0.4.19"
-          }
-        },
-        "ieee754": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-        }
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-lambda-client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-lambda-client/-/lambda-powertools-lambda-client-1.12.0.tgz",
-      "integrity": "sha512-HgqWczhYwzTJ3IFAUfWFHyiKch+1zE9HMSz1dQmI4HJs+WCjlKhxNyC6Vz04aMPmr/vYzfzc1zqvS3NVk1gJMA==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-lambda-client/-/lambda-powertools-lambda-client-1.23.0.tgz",
+      "integrity": "sha1-SwpWs1fS0Pqh7+1GnPhUbG6Sp7Q=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "@dazn/lambda-powertools-logger": "^1.9.0",
-        "aws-sdk": "^2.540.0"
-      },
-      "dependencies": {
-        "aws-sdk": {
-          "version": "2.545.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.545.0.tgz",
-          "integrity": "sha512-oQjpvvTkh2a7CvWhSUcFQWkpfkM3wVpzvLgGMInoZ6QIOsuQ+oNKz+zq48yQ619/GP8XnOh0zBQJLcYaa3XAKw==",
-          "requires": {
-            "buffer": "4.9.1",
-            "events": "1.1.1",
-            "ieee754": "1.1.13",
-            "jmespath": "0.15.0",
-            "querystring": "0.2.0",
-            "sax": "1.2.1",
-            "url": "0.10.3",
-            "uuid": "3.3.2",
-            "xml2js": "0.4.19"
-          }
-        },
-        "ieee754": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-        }
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-logger": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.9.0.tgz",
-      "integrity": "sha512-EN3pxPVWVxn3sr3j/Gfn72A/H8Af8RLyj3FcsSw4kDptG/s46vWP/EYUwecOO02OqX7G+OEObG7AI8+QEgWvCA==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+      "integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2"
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-middleware-correlation-ids": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-correlation-ids/-/lambda-powertools-middleware-correlation-ids-1.11.0.tgz",
-      "integrity": "sha512-GEdorHef20eq0CiBUXvhLZwIND5pxGPHvhOsGTz8cv5+OvugggWPE5F+m7lt//D/GvgKu1l73artBJzHtJWagg==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-correlation-ids/-/lambda-powertools-middleware-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-zZ2GEk87BGIlpCr5KLu5ooPCzOM=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "@dazn/lambda-powertools-logger": "^1.9.0"
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-middleware-log-timeout": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-log-timeout/-/lambda-powertools-middleware-log-timeout-1.9.1.tgz",
-      "integrity": "sha512-+m6Cjm2rgIn2P1a0eEUDF4E4EMh7Z2qkCfWwyerTd7FM89JgM0AxzHMEFMIqyZrGWxtGmi0eR5twP9iTT0QP2Q==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-log-timeout/-/lambda-powertools-middleware-log-timeout-1.23.0.tgz",
+      "integrity": "sha1-vRmwkbD9cYP/9NpBBf159zwTCzo=",
       "requires": {
-        "@dazn/lambda-powertools-logger": "^1.9.0"
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-middleware-obfuscater": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-obfuscater/-/lambda-powertools-middleware-obfuscater-1.9.0.tgz",
-      "integrity": "sha512-+RYZvmXL4HywrAvX+d8vDwc725y4eWuoA3jV3huZpnkdMzGHS7qHp73HV/X3C1hVBvYFZovZ8ieaAlY0nT07yQ==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-obfuscater/-/lambda-powertools-middleware-obfuscater-1.23.0.tgz",
+      "integrity": "sha1-W3C0WkMRP6Lcv0LIyx7hUVx+kxs=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "@dazn/lambda-powertools-logger": "^1.9.0"
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-middleware-sample-logging": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-sample-logging/-/lambda-powertools-middleware-sample-logging-1.9.0.tgz",
-      "integrity": "sha512-diX7gYs8IMvwzlDPlMlDmCarPZa1HSA3QeqlZiOwGM4AD7+CfIiMD4rzbk7OKgr8WA5Rm8y8BToH4D+/n7fxqg==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-sample-logging/-/lambda-powertools-middleware-sample-logging-1.23.0.tgz",
+      "integrity": "sha1-przT9S7BOGZF6OvPC0/u8a+telk=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "@dazn/lambda-powertools-logger": "^1.9.0"
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-middleware-stop-infinite-loop": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-stop-infinite-loop/-/lambda-powertools-middleware-stop-infinite-loop-1.9.0.tgz",
-      "integrity": "sha512-y23vgdRQoUNp7P7eSmnIo2TtXfJdq+tyPgojRkGaUsSBwjW1O3Y5wG978IOQYuDAPtzChoIfp+G3cPy7UxDarQ==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-stop-infinite-loop/-/lambda-powertools-middleware-stop-infinite-loop-1.23.0.tgz",
+      "integrity": "sha1-ADSzdEKy9TxVBkCrEGMA0uTgUz8=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "@dazn/lambda-powertools-logger": "^1.9.0"
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-pattern-basic": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-pattern-basic/-/lambda-powertools-pattern-basic-1.11.0.tgz",
-      "integrity": "sha512-UHsnke+Lz3dhsuNGliqLLajUYNzDO6RZ4YMy2SaSEG8aeiUI81w/Km1d6H2JMaAbZ3cMROwuq2JVboy0NC5Kkg==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-pattern-basic/-/lambda-powertools-pattern-basic-1.23.0.tgz",
+      "integrity": "sha1-7qww1d4YyqNUG9f6T88ToxLbj34=",
       "requires": {
-        "@dazn/lambda-powertools-middleware-correlation-ids": "^1.11.0",
-        "@dazn/lambda-powertools-middleware-log-timeout": "^1.9.1",
-        "@dazn/lambda-powertools-middleware-sample-logging": "^1.9.0",
-        "middy": "^0.15.0"
+        "@dazn/lambda-powertools-middleware-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-middleware-log-timeout": "1.23.0",
+        "@dazn/lambda-powertools-middleware-sample-logging": "1.23.0",
+        "middy": "0.15.10"
       }
     },
     "@dazn/lambda-powertools-pattern-obfuscate": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-pattern-obfuscate/-/lambda-powertools-pattern-obfuscate-1.12.1.tgz",
-      "integrity": "sha512-PXlnRN+CeVGviHWnUE9DN1D+RzdpkJmp1GDWRt+uNktGlET6zCAxGIRTPIUGUPGEUytb0zDaKpshu0KWjlbk0Q==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-pattern-obfuscate/-/lambda-powertools-pattern-obfuscate-1.23.0.tgz",
+      "integrity": "sha1-Bklc4kw3LRm2ecebm0bAYf4yotk=",
       "requires": {
-        "@dazn/lambda-powertools-middleware-correlation-ids": "^1.11.0",
-        "@dazn/lambda-powertools-middleware-log-timeout": "^1.9.1",
-        "@dazn/lambda-powertools-middleware-obfuscater": "^1.9.0",
-        "@dazn/lambda-powertools-middleware-sample-logging": "^1.9.0",
-        "middy": "^0.15.0"
+        "@dazn/lambda-powertools-middleware-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-middleware-log-timeout": "1.23.0",
+        "@dazn/lambda-powertools-middleware-obfuscater": "1.23.0",
+        "@dazn/lambda-powertools-middleware-sample-logging": "1.23.0",
+        "middy": "0.15.10"
       }
     },
     "@dazn/lambda-powertools-sns-client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-sns-client/-/lambda-powertools-sns-client-1.12.0.tgz",
-      "integrity": "sha512-LWuGjk8tJa7/S4a6aA56e1p3nSDlfFVOskFQJojz0ubZnnhdsIpiCXu77oUTL93mNclzOnZbUqpCrdKT1R1Jzg==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-sns-client/-/lambda-powertools-sns-client-1.23.0.tgz",
+      "integrity": "sha1-CtXZQoMumbvN30Ih/COvnNXqWQw=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "aws-sdk": "^2.540.0"
-      },
-      "dependencies": {
-        "aws-sdk": {
-          "version": "2.545.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.545.0.tgz",
-          "integrity": "sha512-oQjpvvTkh2a7CvWhSUcFQWkpfkM3wVpzvLgGMInoZ6QIOsuQ+oNKz+zq48yQ619/GP8XnOh0zBQJLcYaa3XAKw==",
-          "requires": {
-            "buffer": "4.9.1",
-            "events": "1.1.1",
-            "ieee754": "1.1.13",
-            "jmespath": "0.15.0",
-            "querystring": "0.2.0",
-            "sax": "1.2.1",
-            "url": "0.10.3",
-            "uuid": "3.3.2",
-            "xml2js": "0.4.19"
-          }
-        },
-        "ieee754": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-        }
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-sqs-client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-sqs-client/-/lambda-powertools-sqs-client-1.12.0.tgz",
-      "integrity": "sha512-9wGQTbR/+pugvL9gbz9Dh3ajKniqQzrApFOu4yIkk7EnhaplIYzKR3KjgketChO62ZqG9AINWFTCh1RsWcscLA==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-sqs-client/-/lambda-powertools-sqs-client-1.23.0.tgz",
+      "integrity": "sha1-H53No/x3nMxPwJ/qjN3p64oiuf8=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "aws-sdk": "^2.540.0"
-      },
-      "dependencies": {
-        "aws-sdk": {
-          "version": "2.545.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.545.0.tgz",
-          "integrity": "sha512-oQjpvvTkh2a7CvWhSUcFQWkpfkM3wVpzvLgGMInoZ6QIOsuQ+oNKz+zq48yQ619/GP8XnOh0zBQJLcYaa3XAKw==",
-          "requires": {
-            "buffer": "4.9.1",
-            "events": "1.1.1",
-            "ieee754": "1.1.13",
-            "jmespath": "0.15.0",
-            "querystring": "0.2.0",
-            "sax": "1.2.1",
-            "url": "0.10.3",
-            "uuid": "3.3.2",
-            "xml2js": "0.4.19"
-          }
-        },
-        "ieee754": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-        }
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
       }
     },
     "@dazn/lambda-powertools-step-functions-client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-step-functions-client/-/lambda-powertools-step-functions-client-1.12.0.tgz",
-      "integrity": "sha512-XG6ykIgDqRbrKa9zJ+ErzLPVsxMjlahxY3Xtzj2coJVR/6BOZM+MVy+WMdwKf43OyFbGBz5BPrM2kDjxS9QfNw==",
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-step-functions-client/-/lambda-powertools-step-functions-client-1.23.0.tgz",
+      "integrity": "sha1-PQvn70YfA/nwVIJFUQ4A2fGTNJk=",
       "requires": {
-        "@dazn/lambda-powertools-correlation-ids": "^1.8.2",
-        "@dazn/lambda-powertools-logger": "^1.9.0",
-        "aws-sdk": "^2.540.0"
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
       }
     },
     "@types/aws-lambda": {
@@ -291,10 +179,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ajv-i18n": {
@@ -312,55 +200,17 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "aws-sdk": {
-      "version": "2.545.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.545.0.tgz",
-      "integrity": "sha512-oQjpvvTkh2a7CvWhSUcFQWkpfkM3wVpzvLgGMInoZ6QIOsuQ+oNKz+zq48yQ619/GP8XnOh0zBQJLcYaa3XAKw==",
-      "requires": {
-        "buffer": "4.9.1",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
-      },
-      "dependencies": {
-        "ieee754": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-        }
-      }
-    },
-    "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-    },
     "bignumber.js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.1.1.tgz",
       "integrity": "sha1-GkFdmsAUwTJWrx/u2dGj5XF6jPc="
-    },
-    "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      }
     },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "component-emitter": {
@@ -420,16 +270,11 @@
       "resolved": "https://registry.npmjs.org/dogapi/-/dogapi-1.1.0.tgz",
       "integrity": "sha1-caQ4Za1LtMsYvD4Tz3aZcfUBAwo=",
       "requires": {
-        "extend": "^3.0.0",
-        "json-bigint": "^0.1.4",
-        "minimist": "^1.1.1",
-        "rc": "^1.0.0"
+        "extend": "3.0.2",
+        "json-bigint": "0.1.4",
+        "minimist": "1.2.0",
+        "rc": "1.2.8"
       }
-    },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "extend": {
       "version": "3.0.2",
@@ -451,9 +296,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
       "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.8",
+        "mime-types": "2.1.24"
       }
     },
     "formidable": {
@@ -466,17 +311,12 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
       "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "1.5.0",
         "toidentifier": "1.0.0"
       }
-    },
-    "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "inherits": {
       "version": "2.0.4",
@@ -493,17 +333,12 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
     "json-bigint": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.1.4.tgz",
       "integrity": "sha1-tdQLipAJ6S8Vf3wHnbCXABgw4B4=",
       "requires": {
-        "bignumber.js": "~1.1.1"
+        "bignumber.js": "1.1.1"
       }
     },
     "json-mask": {
@@ -516,6 +351,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -526,18 +366,18 @@
       "resolved": "https://registry.npmjs.org/middy/-/middy-0.15.10.tgz",
       "integrity": "sha1-RbBik/LxcgTXTYeJS6TrbhyDuVI=",
       "requires": {
-        "@types/aws-lambda": "^8.10.1",
-        "@types/http-errors": "^1.6.1",
-        "ajv": "^6.0.0",
-        "ajv-i18n": "^3.1.0",
-        "ajv-keywords": "^3.0.0",
-        "content-type": "^1.0.4",
-        "http-errors": "^1.6.2",
-        "json-mask": "^0.3.8",
-        "negotiator": "^0.6.1",
-        "once": "^1.4.0",
-        "qs": "^6.5.0",
-        "querystring": "^0.2.0"
+        "@types/aws-lambda": "8.10.31",
+        "@types/http-errors": "1.6.2",
+        "ajv": "6.10.2",
+        "ajv-i18n": "3.5.0",
+        "ajv-keywords": "3.4.1",
+        "content-type": "1.0.4",
+        "http-errors": "1.7.3",
+        "json-mask": "0.3.8",
+        "negotiator": "0.6.2",
+        "once": "1.4.0",
+        "qs": "6.8.0",
+        "querystring": "0.2.0"
       }
     },
     "mime": {
@@ -578,18 +418,13 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "qs": {
       "version": "6.8.0",
@@ -606,10 +441,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       }
     },
     "readable-stream": {
@@ -617,24 +452,19 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.4",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.1",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -651,7 +481,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-json-comments": {
@@ -664,16 +494,16 @@
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
       "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
+        "component-emitter": "1.3.0",
+        "cookiejar": "2.1.2",
+        "debug": "3.1.0",
+        "extend": "3.0.2",
+        "form-data": "2.5.1",
+        "formidable": "1.2.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "qs": "6.8.0",
+        "readable-stream": "2.3.6"
       }
     },
     "superagent-promise": {
@@ -691,7 +521,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
@@ -701,43 +531,15 @@
         }
       }
     },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,12 @@
 					"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
 					"dev": true
 				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+					"dev": true
+				},
 				"meow": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
@@ -158,6 +164,14 @@
 				"@commitlint/rules": "^7.5.2",
 				"babel-runtime": "^6.23.0",
 				"lodash": "4.17.11"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+					"dev": true
+				}
 			}
 		},
 		"@commitlint/load": {
@@ -229,6 +243,12 @@
 						"through2": "^2.0.0",
 						"trim-off-newlines": "^1.0.0"
 					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
 				}
 			}
 		},
@@ -2935,14 +2955,14 @@
 			"integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
 			"dev": true
 		},
-		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 			"dev": true,
+			"optional": true,
 			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
+				"file-uri-to-path": "1.0.0"
 			}
 		},
 		"block-stream": {
@@ -3035,28 +3055,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
 			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
-			"dev": true
-		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"dev": true,
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
 			"dev": true
 		},
 		"buffer-from": {
@@ -3306,50 +3304,6 @@
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
 			"dev": true
-		},
-		"cliui": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-			"dev": true,
-			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
 		},
 		"clone": {
 			"version": "1.0.4",
@@ -5260,6 +5214,13 @@
 				"flat-cache": "^2.0.1"
 			}
 		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
+		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -5398,12 +5359,6 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
-		"fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-			"dev": true
-		},
 		"fs-extra": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -5451,14 +5406,15 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+			"version": "1.2.12",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+			"integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"bindings": "^1.5.0",
+				"nan": "^2.12.1",
+				"node-pre-gyp": "*"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -5491,10 +5447,22 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
 				},
 				"chownr": {
-					"version": "1.1.1",
+					"version": "1.1.4",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -5507,7 +5475,9 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
@@ -5522,13 +5492,12 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.6",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"deep-extend": {
@@ -5550,12 +5519,12 @@
 					"optional": true
 				},
 				"fs-minipass": {
-					"version": "1.2.5",
+					"version": "1.2.7",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "^2.6.0"
 					}
 				},
 				"fs.realpath": {
@@ -5581,7 +5550,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.3",
+					"version": "7.1.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -5610,7 +5579,7 @@
 					}
 				},
 				"ignore-walk": {
-					"version": "3.0.1",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -5629,7 +5598,7 @@
 					}
 				},
 				"inherits": {
-					"version": "2.0.3",
+					"version": "2.0.4",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -5665,13 +5634,13 @@
 					}
 				},
 				"minimist": {
-					"version": "0.0.8",
+					"version": "1.2.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.3.5",
+					"version": "2.9.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -5681,42 +5650,42 @@
 					}
 				},
 				"minizlib": {
-					"version": "1.2.1",
+					"version": "1.3.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "^2.9.0"
 					}
 				},
 				"mkdirp": {
-					"version": "0.5.1",
+					"version": "0.5.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimist": "0.0.8"
+						"minimist": "^1.2.5"
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
+					"version": "2.1.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.4",
+					"version": "2.3.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
+						"debug": "^3.2.6",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.3",
+					"version": "0.14.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -5730,11 +5699,11 @@
 						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
-						"tar": "^4"
+						"tar": "^4.4.2"
 					}
 				},
 				"nopt": {
-					"version": "4.0.1",
+					"version": "4.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -5744,19 +5713,29 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.5",
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"npm-normalize-package-bin": "^1.0.1"
+					}
+				},
+				"npm-normalize-package-bin": {
+					"version": "1.0.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.2.0",
+					"version": "1.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"npm-bundled": "^1.0.1",
+						"npm-normalize-package-bin": "^1.0.1"
 					}
 				},
 				"npmlog": {
@@ -5821,7 +5800,7 @@
 					"optional": true
 				},
 				"process-nextick-args": {
-					"version": "2.0.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -5836,18 +5815,10 @@
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.6",
+					"version": "2.3.7",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -5862,7 +5833,7 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.3",
+					"version": "2.7.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -5889,7 +5860,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.6.0",
+					"version": "5.7.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -5943,8 +5914,7 @@
 				},
 				"tar": {
 					"version": "4.4.13",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -5955,19 +5925,6 @@
 						"mkdirp": "^0.5.0",
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.3"
-					},
-					"dependencies": {
-						"minipass": {
-							"version": "2.9.0",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						}
 					}
 				},
 				"util-deprecate": {
@@ -5992,7 +5949,7 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.3",
+					"version": "3.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -6072,12 +6029,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
 			"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
-			"dev": true
-		},
-		"get-caller-file": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 			"dev": true
 		},
 		"get-own-enumerable-property-symbols": {
@@ -6424,6 +6375,2955 @@
 					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
 					"dev": true
 				},
+				"npm": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/npm/-/npm-5.1.0.tgz",
+					"integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
+					"dev": true,
+					"requires": {
+						"JSONStream": "~1.3.1",
+						"abbrev": "~1.1.0",
+						"ansi-regex": "~3.0.0",
+						"ansicolors": "~0.3.2",
+						"ansistyles": "~0.1.3",
+						"aproba": "~1.1.2",
+						"archy": "~1.0.0",
+						"bluebird": "~3.5.0",
+						"cacache": "~9.2.9",
+						"call-limit": "~1.1.0",
+						"chownr": "~1.0.1",
+						"cmd-shim": "~2.0.2",
+						"columnify": "~1.5.4",
+						"config-chain": "~1.1.11",
+						"debuglog": "*",
+						"detect-indent": "~5.0.0",
+						"dezalgo": "~1.0.3",
+						"editor": "~1.0.0",
+						"fs-vacuum": "~1.2.10",
+						"fs-write-stream-atomic": "~1.0.10",
+						"fstream": "~1.0.11",
+						"fstream-npm": "~1.2.1",
+						"glob": "~7.1.2",
+						"graceful-fs": "~4.1.11",
+						"has-unicode": "~2.0.1",
+						"hosted-git-info": "~2.5.0",
+						"iferr": "~0.1.5",
+						"imurmurhash": "*",
+						"inflight": "~1.0.6",
+						"inherits": "~2.0.3",
+						"ini": "~1.3.4",
+						"init-package-json": "~1.10.1",
+						"lazy-property": "~1.0.0",
+						"lockfile": "~1.0.3",
+						"lodash._baseindexof": "*",
+						"lodash._baseuniq": "~4.6.0",
+						"lodash._bindcallback": "*",
+						"lodash._cacheindexof": "*",
+						"lodash._createcache": "*",
+						"lodash._getnative": "*",
+						"lodash.clonedeep": "~4.5.0",
+						"lodash.restparam": "*",
+						"lodash.union": "~4.6.0",
+						"lodash.uniq": "~4.5.0",
+						"lodash.without": "~4.4.0",
+						"lru-cache": "~4.1.1",
+						"mississippi": "~1.3.0",
+						"mkdirp": "~0.5.1",
+						"move-concurrently": "~1.0.1",
+						"node-gyp": "~3.6.2",
+						"nopt": "~4.0.1",
+						"normalize-package-data": "~2.4.0",
+						"npm-cache-filename": "~1.0.2",
+						"npm-install-checks": "~3.0.0",
+						"npm-package-arg": "~5.1.2",
+						"npm-registry-client": "~8.4.0",
+						"npm-user-validate": "~1.0.0",
+						"npmlog": "~4.1.2",
+						"once": "~1.4.0",
+						"opener": "~1.4.3",
+						"osenv": "~0.1.4",
+						"pacote": "~2.7.38",
+						"path-is-inside": "~1.0.2",
+						"promise-inflight": "~1.0.1",
+						"read": "~1.0.7",
+						"read-cmd-shim": "~1.0.1",
+						"read-installed": "~4.0.3",
+						"read-package-json": "~2.0.9",
+						"read-package-tree": "~5.1.6",
+						"readable-stream": "~2.3.2",
+						"readdir-scoped-modules": "*",
+						"request": "~2.81.0",
+						"retry": "~0.10.1",
+						"rimraf": "~2.6.1",
+						"safe-buffer": "~5.1.1",
+						"semver": "~5.3.0",
+						"sha": "~2.0.1",
+						"slide": "~1.1.6",
+						"sorted-object": "~2.0.1",
+						"sorted-union-stream": "~2.1.3",
+						"ssri": "~4.1.6",
+						"strip-ansi": "~4.0.0",
+						"tar": "~2.2.1",
+						"text-table": "~0.2.0",
+						"uid-number": "0.0.6",
+						"umask": "~1.1.0",
+						"unique-filename": "~1.1.0",
+						"unpipe": "~1.0.0",
+						"update-notifier": "~2.2.0",
+						"uuid": "~3.1.0",
+						"validate-npm-package-license": "*",
+						"validate-npm-package-name": "~3.0.0",
+						"which": "~1.2.14",
+						"worker-farm": "~1.3.1",
+						"wrappy": "~1.0.2",
+						"write-file-atomic": "~2.1.0"
+					},
+					"dependencies": {
+						"JSONStream": {
+							"version": "1.3.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"jsonparse": "^1.2.0",
+								"through": ">=2.2.7 <3"
+							},
+							"dependencies": {
+								"jsonparse": {
+									"version": "1.3.1",
+									"bundled": true,
+									"dev": true
+								},
+								"through": {
+									"version": "2.3.8",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"abbrev": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"ansicolors": {
+							"version": "0.3.2",
+							"bundled": true,
+							"dev": true
+						},
+						"ansistyles": {
+							"version": "0.1.3",
+							"bundled": true,
+							"dev": true
+						},
+						"aproba": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true
+						},
+						"archy": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"bluebird": {
+							"version": "3.5.0",
+							"bundled": true,
+							"dev": true
+						},
+						"cacache": {
+							"version": "9.2.9",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"bluebird": "^3.5.0",
+								"chownr": "^1.0.1",
+								"glob": "^7.1.2",
+								"graceful-fs": "^4.1.11",
+								"lru-cache": "^4.1.1",
+								"mississippi": "^1.3.0",
+								"mkdirp": "^0.5.1",
+								"move-concurrently": "^1.0.1",
+								"promise-inflight": "^1.0.1",
+								"rimraf": "^2.6.1",
+								"ssri": "^4.1.6",
+								"unique-filename": "^1.1.0",
+								"y18n": "^3.2.1"
+							},
+							"dependencies": {
+								"lru-cache": {
+									"version": "4.1.1",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"pseudomap": "^1.0.2",
+										"yallist": "^2.1.2"
+									},
+									"dependencies": {
+										"pseudomap": {
+											"version": "1.0.2",
+											"bundled": true,
+											"dev": true
+										},
+										"yallist": {
+											"version": "2.1.2",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"y18n": {
+									"version": "3.2.1",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"call-limit": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"chownr": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"cmd-shim": {
+							"version": "2.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.1.2",
+								"mkdirp": "~0.5.0"
+							}
+						},
+						"columnify": {
+							"version": "1.5.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"strip-ansi": "^3.0.0",
+								"wcwidth": "^1.0.0"
+							},
+							"dependencies": {
+								"strip-ansi": {
+									"version": "3.0.1",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"ansi-regex": "^2.0.0"
+									},
+									"dependencies": {
+										"ansi-regex": {
+											"version": "2.1.1",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"wcwidth": {
+									"version": "1.0.1",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"defaults": "^1.0.3"
+									},
+									"dependencies": {
+										"defaults": {
+											"version": "1.0.3",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"clone": "^1.0.2"
+											},
+											"dependencies": {
+												"clone": {
+													"version": "1.0.2",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										}
+									}
+								}
+							}
+						},
+						"config-chain": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ini": "^1.3.4",
+								"proto-list": "~1.2.1"
+							},
+							"dependencies": {
+								"proto-list": {
+									"version": "1.2.4",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"debuglog": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"detect-indent": {
+							"version": "5.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"dezalgo": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"asap": "^2.0.0",
+								"wrappy": "1"
+							},
+							"dependencies": {
+								"asap": {
+									"version": "2.0.5",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"editor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"fs-vacuum": {
+							"version": "1.2.10",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.1.2",
+								"path-is-inside": "^1.0.1",
+								"rimraf": "^2.5.2"
+							}
+						},
+						"fs-write-stream-atomic": {
+							"version": "1.0.10",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.1.2",
+								"iferr": "^0.1.5",
+								"imurmurhash": "^0.1.4",
+								"readable-stream": "1 || 2"
+							}
+						},
+						"fstream": {
+							"version": "1.0.11",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.1.2",
+								"inherits": "~2.0.0",
+								"mkdirp": ">=0.5 0",
+								"rimraf": "2"
+							}
+						},
+						"fstream-npm": {
+							"version": "1.2.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"fstream-ignore": "^1.0.0",
+								"inherits": "2"
+							},
+							"dependencies": {
+								"fstream-ignore": {
+									"version": "1.0.5",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"fstream": "^1.0.0",
+										"inherits": "2",
+										"minimatch": "^3.0.0"
+									},
+									"dependencies": {
+										"minimatch": {
+											"version": "3.0.4",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"brace-expansion": "^1.1.7"
+											},
+											"dependencies": {
+												"brace-expansion": {
+													"version": "1.1.8",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"balanced-match": "^1.0.0",
+														"concat-map": "0.0.1"
+													},
+													"dependencies": {
+														"balanced-match": {
+															"version": "1.0.0",
+															"bundled": true,
+															"dev": true
+														},
+														"concat-map": {
+															"version": "0.0.1",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							},
+							"dependencies": {
+								"fs.realpath": {
+									"version": "1.0.0",
+									"bundled": true,
+									"dev": true
+								},
+								"minimatch": {
+									"version": "3.0.4",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"brace-expansion": "^1.1.7"
+									},
+									"dependencies": {
+										"brace-expansion": {
+											"version": "1.1.8",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"balanced-match": "^1.0.0",
+												"concat-map": "0.0.1"
+											},
+											"dependencies": {
+												"balanced-match": {
+													"version": "1.0.0",
+													"bundled": true,
+													"dev": true
+												},
+												"concat-map": {
+													"version": "0.0.1",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										}
+									}
+								},
+								"path-is-absolute": {
+									"version": "1.0.1",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"graceful-fs": {
+							"version": "4.1.11",
+							"bundled": true,
+							"dev": true
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"hosted-git-info": {
+							"version": "2.5.0",
+							"bundled": true,
+							"dev": true
+						},
+						"iferr": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true
+						},
+						"imurmurhash": {
+							"version": "0.1.4",
+							"bundled": true,
+							"dev": true
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"dev": true
+						},
+						"ini": {
+							"version": "1.3.4",
+							"bundled": true,
+							"dev": true
+						},
+						"init-package-json": {
+							"version": "1.10.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"glob": "^7.1.1",
+								"npm-package-arg": "^4.0.0 || ^5.0.0",
+								"promzard": "^0.3.0",
+								"read": "~1.0.1",
+								"read-package-json": "1 || 2",
+								"semver": "2.x || 3.x || 4 || 5",
+								"validate-npm-package-license": "^3.0.1",
+								"validate-npm-package-name": "^3.0.0"
+							},
+							"dependencies": {
+								"promzard": {
+									"version": "0.3.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"read": "1"
+									}
+								}
+							}
+						},
+						"lazy-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"lockfile": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true
+						},
+						"lodash._baseindexof": {
+							"version": "3.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"lodash._baseuniq": {
+							"version": "4.6.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"lodash._createset": "~4.0.0",
+								"lodash._root": "~3.0.0"
+							},
+							"dependencies": {
+								"lodash._createset": {
+									"version": "4.0.3",
+									"bundled": true,
+									"dev": true
+								},
+								"lodash._root": {
+									"version": "3.0.1",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"lodash._bindcallback": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"lodash._cacheindexof": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true
+						},
+						"lodash._createcache": {
+							"version": "3.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"lodash._getnative": "^3.0.0"
+							}
+						},
+						"lodash._getnative": {
+							"version": "3.9.1",
+							"bundled": true,
+							"dev": true
+						},
+						"lodash.clonedeep": {
+							"version": "4.5.0",
+							"bundled": true,
+							"dev": true
+						},
+						"lodash.restparam": {
+							"version": "3.6.1",
+							"bundled": true,
+							"dev": true
+						},
+						"lodash.union": {
+							"version": "4.6.0",
+							"bundled": true,
+							"dev": true
+						},
+						"lodash.uniq": {
+							"version": "4.5.0",
+							"bundled": true,
+							"dev": true
+						},
+						"lodash.without": {
+							"version": "4.4.0",
+							"bundled": true,
+							"dev": true
+						},
+						"lru-cache": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
+							},
+							"dependencies": {
+								"pseudomap": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true
+								},
+								"yallist": {
+									"version": "2.1.2",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"mississippi": {
+							"version": "1.3.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"concat-stream": "^1.5.0",
+								"duplexify": "^3.4.2",
+								"end-of-stream": "^1.1.0",
+								"flush-write-stream": "^1.0.0",
+								"from2": "^2.1.0",
+								"parallel-transform": "^1.1.0",
+								"pump": "^1.0.0",
+								"pumpify": "^1.3.3",
+								"stream-each": "^1.1.0",
+								"through2": "^2.0.0"
+							},
+							"dependencies": {
+								"concat-stream": {
+									"version": "1.6.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"inherits": "^2.0.3",
+										"readable-stream": "^2.2.2",
+										"typedarray": "^0.0.6"
+									},
+									"dependencies": {
+										"typedarray": {
+											"version": "0.0.6",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"duplexify": {
+									"version": "3.5.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"end-of-stream": "1.0.0",
+										"inherits": "^2.0.1",
+										"readable-stream": "^2.0.0",
+										"stream-shift": "^1.0.0"
+									},
+									"dependencies": {
+										"end-of-stream": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"once": "~1.3.0"
+											},
+											"dependencies": {
+												"once": {
+													"version": "1.3.3",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"wrappy": "1"
+													}
+												}
+											}
+										},
+										"stream-shift": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"end-of-stream": {
+									"version": "1.4.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"once": "^1.4.0"
+									}
+								},
+								"flush-write-stream": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"inherits": "^2.0.1",
+										"readable-stream": "^2.0.4"
+									}
+								},
+								"from2": {
+									"version": "2.3.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"inherits": "^2.0.1",
+										"readable-stream": "^2.0.0"
+									}
+								},
+								"parallel-transform": {
+									"version": "1.1.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"cyclist": "~0.2.2",
+										"inherits": "^2.0.3",
+										"readable-stream": "^2.1.5"
+									},
+									"dependencies": {
+										"cyclist": {
+											"version": "0.2.2",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"pump": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"end-of-stream": "^1.1.0",
+										"once": "^1.3.1"
+									}
+								},
+								"pumpify": {
+									"version": "1.3.5",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"duplexify": "^3.1.2",
+										"inherits": "^2.0.1",
+										"pump": "^1.0.0"
+									}
+								},
+								"stream-each": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"end-of-stream": "^1.1.0",
+										"stream-shift": "^1.0.0"
+									},
+									"dependencies": {
+										"stream-shift": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"through2": {
+									"version": "2.0.3",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"readable-stream": "^2.1.5",
+										"xtend": "~4.0.1"
+									},
+									"dependencies": {
+										"xtend": {
+											"version": "4.0.1",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								}
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"minimist": "0.0.8"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "0.0.8",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"move-concurrently": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"aproba": "^1.1.1",
+								"copy-concurrently": "^1.0.0",
+								"fs-write-stream-atomic": "^1.0.8",
+								"mkdirp": "^0.5.1",
+								"rimraf": "^2.5.4",
+								"run-queue": "^1.0.3"
+							},
+							"dependencies": {
+								"copy-concurrently": {
+									"version": "1.0.3",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"aproba": "^1.1.1",
+										"fs-write-stream-atomic": "^1.0.8",
+										"iferr": "^0.1.5",
+										"mkdirp": "^0.5.1",
+										"rimraf": "^2.5.4",
+										"run-queue": "^1.0.0"
+									}
+								},
+								"run-queue": {
+									"version": "1.0.3",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"aproba": "^1.1.1"
+									}
+								}
+							}
+						},
+						"node-gyp": {
+							"version": "3.6.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"fstream": "^1.0.0",
+								"glob": "^7.0.3",
+								"graceful-fs": "^4.1.2",
+								"minimatch": "^3.0.2",
+								"mkdirp": "^0.5.0",
+								"nopt": "2 || 3",
+								"npmlog": "0 || 1 || 2 || 3 || 4",
+								"osenv": "0",
+								"request": "2",
+								"rimraf": "2",
+								"semver": "~5.3.0",
+								"tar": "^2.0.0",
+								"which": "1"
+							},
+							"dependencies": {
+								"minimatch": {
+									"version": "3.0.4",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"brace-expansion": "^1.1.7"
+									},
+									"dependencies": {
+										"brace-expansion": {
+											"version": "1.1.8",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"balanced-match": "^1.0.0",
+												"concat-map": "0.0.1"
+											},
+											"dependencies": {
+												"balanced-match": {
+													"version": "1.0.0",
+													"bundled": true,
+													"dev": true
+												},
+												"concat-map": {
+													"version": "0.0.1",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										}
+									}
+								},
+								"nopt": {
+									"version": "3.0.6",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"abbrev": "1"
+									}
+								}
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"normalize-package-data": {
+							"version": "2.4.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"hosted-git-info": "^2.1.4",
+								"is-builtin-module": "^1.0.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
+							},
+							"dependencies": {
+								"is-builtin-module": {
+									"version": "1.0.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"builtin-modules": "^1.0.0"
+									},
+									"dependencies": {
+										"builtin-modules": {
+											"version": "1.1.1",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								}
+							}
+						},
+						"npm-cache-filename": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true
+						},
+						"npm-install-checks": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"semver": "^2.3.0 || 3.x || 4 || 5"
+							}
+						},
+						"npm-package-arg": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"hosted-git-info": "^2.4.2",
+								"osenv": "^0.1.4",
+								"semver": "^5.1.0",
+								"validate-npm-package-name": "^3.0.0"
+							}
+						},
+						"npm-registry-client": {
+							"version": "8.4.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"concat-stream": "^1.5.2",
+								"graceful-fs": "^4.1.6",
+								"normalize-package-data": "~1.0.1 || ^2.0.0",
+								"npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
+								"npmlog": "2 || ^3.1.0 || ^4.0.0",
+								"once": "^1.3.3",
+								"request": "^2.74.0",
+								"retry": "^0.10.0",
+								"semver": "2 >=2.2.1 || 3.x || 4 || 5",
+								"slide": "^1.1.3",
+								"ssri": "^4.1.2"
+							},
+							"dependencies": {
+								"concat-stream": {
+									"version": "1.6.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"inherits": "^2.0.3",
+										"readable-stream": "^2.2.2",
+										"typedarray": "^0.0.6"
+									},
+									"dependencies": {
+										"typedarray": {
+											"version": "0.0.6",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								}
+							}
+						},
+						"npm-user-validate": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							},
+							"dependencies": {
+								"are-we-there-yet": {
+									"version": "1.1.4",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"delegates": "^1.0.0",
+										"readable-stream": "^2.0.6"
+									},
+									"dependencies": {
+										"delegates": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"console-control-strings": {
+									"version": "1.1.0",
+									"bundled": true,
+									"dev": true
+								},
+								"gauge": {
+									"version": "2.7.4",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"aproba": "^1.0.3",
+										"console-control-strings": "^1.0.0",
+										"has-unicode": "^2.0.0",
+										"object-assign": "^4.1.0",
+										"signal-exit": "^3.0.0",
+										"string-width": "^1.0.1",
+										"strip-ansi": "^3.0.1",
+										"wide-align": "^1.1.0"
+									},
+									"dependencies": {
+										"object-assign": {
+											"version": "4.1.1",
+											"bundled": true,
+											"dev": true
+										},
+										"signal-exit": {
+											"version": "3.0.2",
+											"bundled": true,
+											"dev": true
+										},
+										"string-width": {
+											"version": "1.0.2",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"code-point-at": "^1.0.0",
+												"is-fullwidth-code-point": "^1.0.0",
+												"strip-ansi": "^3.0.0"
+											},
+											"dependencies": {
+												"code-point-at": {
+													"version": "1.1.0",
+													"bundled": true,
+													"dev": true
+												},
+												"is-fullwidth-code-point": {
+													"version": "1.0.0",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"number-is-nan": "^1.0.0"
+													},
+													"dependencies": {
+														"number-is-nan": {
+															"version": "1.0.1",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												}
+											}
+										},
+										"strip-ansi": {
+											"version": "3.0.1",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"ansi-regex": "^2.0.0"
+											},
+											"dependencies": {
+												"ansi-regex": {
+													"version": "2.1.1",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										},
+										"wide-align": {
+											"version": "1.1.2",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"string-width": "^1.0.2"
+											}
+										}
+									}
+								},
+								"set-blocking": {
+									"version": "2.0.0",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"opener": {
+							"version": "1.4.3",
+							"bundled": true,
+							"dev": true
+						},
+						"osenv": {
+							"version": "0.1.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							},
+							"dependencies": {
+								"os-homedir": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true
+								},
+								"os-tmpdir": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"pacote": {
+							"version": "2.7.38",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"bluebird": "^3.5.0",
+								"cacache": "^9.2.9",
+								"glob": "^7.1.2",
+								"lru-cache": "^4.1.1",
+								"make-fetch-happen": "^2.4.13",
+								"minimatch": "^3.0.4",
+								"mississippi": "^1.2.0",
+								"normalize-package-data": "^2.4.0",
+								"npm-package-arg": "^5.1.2",
+								"npm-pick-manifest": "^1.0.4",
+								"osenv": "^0.1.4",
+								"promise-inflight": "^1.0.1",
+								"promise-retry": "^1.1.1",
+								"protoduck": "^4.0.0",
+								"safe-buffer": "^5.1.1",
+								"semver": "^5.3.0",
+								"ssri": "^4.1.6",
+								"tar-fs": "^1.15.3",
+								"tar-stream": "^1.5.4",
+								"unique-filename": "^1.1.0",
+								"which": "^1.2.12"
+							},
+							"dependencies": {
+								"make-fetch-happen": {
+									"version": "2.4.13",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"agentkeepalive": "^3.3.0",
+										"cacache": "^9.2.9",
+										"http-cache-semantics": "^3.7.3",
+										"http-proxy-agent": "^2.0.0",
+										"https-proxy-agent": "^2.0.0",
+										"lru-cache": "^4.1.1",
+										"mississippi": "^1.2.0",
+										"node-fetch-npm": "^2.0.1",
+										"promise-retry": "^1.1.1",
+										"socks-proxy-agent": "^3.0.0",
+										"ssri": "^4.1.6"
+									},
+									"dependencies": {
+										"agentkeepalive": {
+											"version": "3.3.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"humanize-ms": "^1.2.1"
+											},
+											"dependencies": {
+												"humanize-ms": {
+													"version": "1.2.1",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"ms": "^2.0.0"
+													},
+													"dependencies": {
+														"ms": {
+															"version": "2.0.0",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												}
+											}
+										},
+										"http-cache-semantics": {
+											"version": "3.7.3",
+											"bundled": true,
+											"dev": true
+										},
+										"http-proxy-agent": {
+											"version": "2.0.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"agent-base": "4",
+												"debug": "2"
+											},
+											"dependencies": {
+												"agent-base": {
+													"version": "4.1.0",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"es6-promisify": "^5.0.0"
+													},
+													"dependencies": {
+														"es6-promisify": {
+															"version": "5.0.0",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"es6-promise": "^4.0.3"
+															},
+															"dependencies": {
+																"es6-promise": {
+																	"version": "4.1.1",
+																	"bundled": true,
+																	"dev": true
+																}
+															}
+														}
+													}
+												},
+												"debug": {
+													"version": "2.6.8",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"ms": "2.0.0"
+													},
+													"dependencies": {
+														"ms": {
+															"version": "2.0.0",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												}
+											}
+										},
+										"https-proxy-agent": {
+											"version": "2.0.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"agent-base": "^4.1.0",
+												"debug": "^2.4.1"
+											},
+											"dependencies": {
+												"agent-base": {
+													"version": "4.1.0",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"es6-promisify": "^5.0.0"
+													},
+													"dependencies": {
+														"es6-promisify": {
+															"version": "5.0.0",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"es6-promise": "^4.0.3"
+															},
+															"dependencies": {
+																"es6-promise": {
+																	"version": "4.1.1",
+																	"bundled": true,
+																	"dev": true
+																}
+															}
+														}
+													}
+												},
+												"debug": {
+													"version": "2.6.8",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"ms": "2.0.0"
+													},
+													"dependencies": {
+														"ms": {
+															"version": "2.0.0",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												}
+											}
+										},
+										"node-fetch-npm": {
+											"version": "2.0.1",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"encoding": "^0.1.11",
+												"json-parse-helpfulerror": "^1.0.3",
+												"safe-buffer": "^5.0.1"
+											},
+											"dependencies": {
+												"encoding": {
+													"version": "0.1.12",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"iconv-lite": "~0.4.13"
+													},
+													"dependencies": {
+														"iconv-lite": {
+															"version": "0.4.18",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												},
+												"json-parse-helpfulerror": {
+													"version": "1.0.3",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"jju": "^1.1.0"
+													},
+													"dependencies": {
+														"jju": {
+															"version": "1.3.0",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												}
+											}
+										},
+										"socks-proxy-agent": {
+											"version": "3.0.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"agent-base": "^4.0.1",
+												"socks": "^1.1.10"
+											},
+											"dependencies": {
+												"agent-base": {
+													"version": "4.1.0",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"es6-promisify": "^5.0.0"
+													},
+													"dependencies": {
+														"es6-promisify": {
+															"version": "5.0.0",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"es6-promise": "^4.0.3"
+															},
+															"dependencies": {
+																"es6-promise": {
+																	"version": "4.1.1",
+																	"bundled": true,
+																	"dev": true
+																}
+															}
+														}
+													}
+												},
+												"socks": {
+													"version": "1.1.10",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"ip": "^1.1.4",
+														"smart-buffer": "^1.0.13"
+													},
+													"dependencies": {
+														"ip": {
+															"version": "1.1.5",
+															"bundled": true,
+															"dev": true
+														},
+														"smart-buffer": {
+															"version": "1.1.15",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"minimatch": {
+									"version": "3.0.4",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"brace-expansion": "^1.1.7"
+									},
+									"dependencies": {
+										"brace-expansion": {
+											"version": "1.1.8",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"balanced-match": "^1.0.0",
+												"concat-map": "0.0.1"
+											},
+											"dependencies": {
+												"balanced-match": {
+													"version": "1.0.0",
+													"bundled": true,
+													"dev": true
+												},
+												"concat-map": {
+													"version": "0.0.1",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										}
+									}
+								},
+								"npm-pick-manifest": {
+									"version": "1.0.4",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"npm-package-arg": "^5.1.2",
+										"semver": "^5.3.0"
+									}
+								},
+								"promise-retry": {
+									"version": "1.1.1",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"err-code": "^1.0.0",
+										"retry": "^0.10.0"
+									},
+									"dependencies": {
+										"err-code": {
+											"version": "1.1.2",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"protoduck": {
+									"version": "4.0.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"genfun": "^4.0.1"
+									},
+									"dependencies": {
+										"genfun": {
+											"version": "4.0.1",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"tar-fs": {
+									"version": "1.15.3",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"chownr": "^1.0.1",
+										"mkdirp": "^0.5.1",
+										"pump": "^1.0.0",
+										"tar-stream": "^1.1.2"
+									},
+									"dependencies": {
+										"pump": {
+											"version": "1.0.2",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"end-of-stream": "^1.1.0",
+												"once": "^1.3.1"
+											},
+											"dependencies": {
+												"end-of-stream": {
+													"version": "1.4.0",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"once": "^1.4.0"
+													}
+												}
+											}
+										}
+									}
+								},
+								"tar-stream": {
+									"version": "1.5.4",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"bl": "^1.0.0",
+										"end-of-stream": "^1.0.0",
+										"readable-stream": "^2.0.0",
+										"xtend": "^4.0.0"
+									},
+									"dependencies": {
+										"bl": {
+											"version": "1.2.1",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"readable-stream": "^2.0.5"
+											}
+										},
+										"end-of-stream": {
+											"version": "1.4.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"once": "^1.4.0"
+											}
+										},
+										"xtend": {
+											"version": "4.0.1",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								}
+							}
+						},
+						"path-is-inside": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true
+						},
+						"promise-inflight": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"read": {
+							"version": "1.0.7",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"mute-stream": "~0.0.4"
+							},
+							"dependencies": {
+								"mute-stream": {
+									"version": "0.0.7",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"read-cmd-shim": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.1.2"
+							}
+						},
+						"read-installed": {
+							"version": "4.0.3",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"debuglog": "^1.0.1",
+								"graceful-fs": "^4.1.2",
+								"read-package-json": "^2.0.0",
+								"readdir-scoped-modules": "^1.0.0",
+								"semver": "2 || 3 || 4 || 5",
+								"slide": "~1.1.3",
+								"util-extend": "^1.0.1"
+							},
+							"dependencies": {
+								"util-extend": {
+									"version": "1.0.3",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"read-package-json": {
+							"version": "2.0.9",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"glob": "^7.1.1",
+								"graceful-fs": "^4.1.2",
+								"json-parse-helpfulerror": "^1.0.2",
+								"normalize-package-data": "^2.0.0"
+							},
+							"dependencies": {
+								"json-parse-helpfulerror": {
+									"version": "1.0.3",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"jju": "^1.1.0"
+									},
+									"dependencies": {
+										"jju": {
+											"version": "1.3.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								}
+							}
+						},
+						"read-package-tree": {
+							"version": "5.1.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"debuglog": "^1.0.1",
+								"dezalgo": "^1.0.0",
+								"once": "^1.3.0",
+								"read-package-json": "^2.0.0",
+								"readdir-scoped-modules": "^1.0.0"
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~1.0.6",
+								"safe-buffer": "~5.1.0",
+								"string_decoder": "~1.0.0",
+								"util-deprecate": "~1.0.1"
+							},
+							"dependencies": {
+								"core-util-is": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true
+								},
+								"isarray": {
+									"version": "1.0.0",
+									"bundled": true,
+									"dev": true
+								},
+								"process-nextick-args": {
+									"version": "1.0.7",
+									"bundled": true,
+									"dev": true
+								},
+								"string_decoder": {
+									"version": "1.0.3",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"safe-buffer": "~5.1.0"
+									}
+								},
+								"util-deprecate": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"readdir-scoped-modules": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"debuglog": "^1.0.1",
+								"dezalgo": "^1.0.0",
+								"graceful-fs": "^4.1.2",
+								"once": "^1.3.0"
+							}
+						},
+						"request": {
+							"version": "2.81.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"aws-sign2": "~0.6.0",
+								"aws4": "^1.2.1",
+								"caseless": "~0.12.0",
+								"combined-stream": "~1.0.5",
+								"extend": "~3.0.0",
+								"forever-agent": "~0.6.1",
+								"form-data": "~2.1.1",
+								"har-validator": "~4.2.1",
+								"hawk": "~3.1.3",
+								"http-signature": "~1.1.0",
+								"is-typedarray": "~1.0.0",
+								"isstream": "~0.1.2",
+								"json-stringify-safe": "~5.0.1",
+								"mime-types": "~2.1.7",
+								"oauth-sign": "~0.8.1",
+								"performance-now": "^0.2.0",
+								"qs": "~6.4.0",
+								"safe-buffer": "^5.0.1",
+								"stringstream": "~0.0.4",
+								"tough-cookie": "~2.3.0",
+								"tunnel-agent": "^0.6.0",
+								"uuid": "^3.0.0"
+							},
+							"dependencies": {
+								"aws-sign2": {
+									"version": "0.6.0",
+									"bundled": true,
+									"dev": true
+								},
+								"aws4": {
+									"version": "1.6.0",
+									"bundled": true,
+									"dev": true
+								},
+								"caseless": {
+									"version": "0.12.0",
+									"bundled": true,
+									"dev": true
+								},
+								"combined-stream": {
+									"version": "1.0.5",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"delayed-stream": "~1.0.0"
+									},
+									"dependencies": {
+										"delayed-stream": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"extend": {
+									"version": "3.0.1",
+									"bundled": true,
+									"dev": true
+								},
+								"forever-agent": {
+									"version": "0.6.1",
+									"bundled": true,
+									"dev": true
+								},
+								"form-data": {
+									"version": "2.1.4",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"asynckit": "^0.4.0",
+										"combined-stream": "^1.0.5",
+										"mime-types": "^2.1.12"
+									},
+									"dependencies": {
+										"asynckit": {
+											"version": "0.4.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"har-validator": {
+									"version": "4.2.1",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"ajv": "^4.9.1",
+										"har-schema": "^1.0.5"
+									},
+									"dependencies": {
+										"ajv": {
+											"version": "4.11.8",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"co": "^4.6.0",
+												"json-stable-stringify": "^1.0.1"
+											},
+											"dependencies": {
+												"co": {
+													"version": "4.6.0",
+													"bundled": true,
+													"dev": true
+												},
+												"json-stable-stringify": {
+													"version": "1.0.1",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"jsonify": "~0.0.0"
+													},
+													"dependencies": {
+														"jsonify": {
+															"version": "0.0.0",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												}
+											}
+										},
+										"har-schema": {
+											"version": "1.0.5",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"hawk": {
+									"version": "3.1.3",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"boom": "2.x.x",
+										"cryptiles": "2.x.x",
+										"hoek": "2.x.x",
+										"sntp": "1.x.x"
+									},
+									"dependencies": {
+										"boom": {
+											"version": "2.10.1",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"hoek": "2.x.x"
+											}
+										},
+										"cryptiles": {
+											"version": "2.0.5",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"boom": "2.x.x"
+											}
+										},
+										"hoek": {
+											"version": "2.16.3",
+											"bundled": true,
+											"dev": true
+										},
+										"sntp": {
+											"version": "1.0.9",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"hoek": "2.x.x"
+											}
+										}
+									}
+								},
+								"http-signature": {
+									"version": "1.1.1",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"assert-plus": "^0.2.0",
+										"jsprim": "^1.2.2",
+										"sshpk": "^1.7.0"
+									},
+									"dependencies": {
+										"assert-plus": {
+											"version": "0.2.0",
+											"bundled": true,
+											"dev": true
+										},
+										"jsprim": {
+											"version": "1.4.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"assert-plus": "1.0.0",
+												"extsprintf": "1.0.2",
+												"json-schema": "0.2.3",
+												"verror": "1.3.6"
+											},
+											"dependencies": {
+												"assert-plus": {
+													"version": "1.0.0",
+													"bundled": true,
+													"dev": true
+												},
+												"extsprintf": {
+													"version": "1.0.2",
+													"bundled": true,
+													"dev": true
+												},
+												"json-schema": {
+													"version": "0.2.3",
+													"bundled": true,
+													"dev": true
+												},
+												"verror": {
+													"version": "1.3.6",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"extsprintf": "1.0.2"
+													}
+												}
+											}
+										},
+										"sshpk": {
+											"version": "1.13.1",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"asn1": "~0.2.3",
+												"assert-plus": "^1.0.0",
+												"bcrypt-pbkdf": "^1.0.0",
+												"dashdash": "^1.12.0",
+												"ecc-jsbn": "~0.1.1",
+												"getpass": "^0.1.1",
+												"jsbn": "~0.1.0",
+												"tweetnacl": "~0.14.0"
+											},
+											"dependencies": {
+												"asn1": {
+													"version": "0.2.3",
+													"bundled": true,
+													"dev": true
+												},
+												"assert-plus": {
+													"version": "1.0.0",
+													"bundled": true,
+													"dev": true
+												},
+												"bcrypt-pbkdf": {
+													"version": "1.0.1",
+													"bundled": true,
+													"dev": true,
+													"optional": true,
+													"requires": {
+														"tweetnacl": "^0.14.3"
+													}
+												},
+												"dashdash": {
+													"version": "1.14.1",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"assert-plus": "^1.0.0"
+													}
+												},
+												"ecc-jsbn": {
+													"version": "0.1.1",
+													"bundled": true,
+													"dev": true,
+													"optional": true,
+													"requires": {
+														"jsbn": "~0.1.0"
+													}
+												},
+												"getpass": {
+													"version": "0.1.7",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"assert-plus": "^1.0.0"
+													}
+												},
+												"jsbn": {
+													"version": "0.1.1",
+													"bundled": true,
+													"dev": true,
+													"optional": true
+												},
+												"tweetnacl": {
+													"version": "0.14.5",
+													"bundled": true,
+													"dev": true,
+													"optional": true
+												}
+											}
+										}
+									}
+								},
+								"is-typedarray": {
+									"version": "1.0.0",
+									"bundled": true,
+									"dev": true
+								},
+								"isstream": {
+									"version": "0.1.2",
+									"bundled": true,
+									"dev": true
+								},
+								"json-stringify-safe": {
+									"version": "5.0.1",
+									"bundled": true,
+									"dev": true
+								},
+								"mime-types": {
+									"version": "2.1.15",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"mime-db": "~1.27.0"
+									},
+									"dependencies": {
+										"mime-db": {
+											"version": "1.27.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"oauth-sign": {
+									"version": "0.8.2",
+									"bundled": true,
+									"dev": true
+								},
+								"performance-now": {
+									"version": "0.2.0",
+									"bundled": true,
+									"dev": true
+								},
+								"qs": {
+									"version": "6.4.0",
+									"bundled": true,
+									"dev": true
+								},
+								"stringstream": {
+									"version": "0.0.5",
+									"bundled": true,
+									"dev": true
+								},
+								"tough-cookie": {
+									"version": "2.3.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"punycode": "^1.4.1"
+									},
+									"dependencies": {
+										"punycode": {
+											"version": "1.4.1",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"tunnel-agent": {
+									"version": "0.6.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"safe-buffer": "^5.0.1"
+									}
+								}
+							}
+						},
+						"retry": {
+							"version": "0.10.1",
+							"bundled": true,
+							"dev": true
+						},
+						"rimraf": {
+							"version": "2.6.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"glob": "^7.0.5"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"bundled": true,
+							"dev": true
+						},
+						"semver": {
+							"version": "5.3.0",
+							"bundled": true,
+							"dev": true
+						},
+						"sha": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.1.2",
+								"readable-stream": "^2.0.2"
+							}
+						},
+						"slide": {
+							"version": "1.1.6",
+							"bundled": true,
+							"dev": true
+						},
+						"sorted-object": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"sorted-union-stream": {
+							"version": "2.1.3",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"from2": "^1.3.0",
+								"stream-iterate": "^1.1.0"
+							},
+							"dependencies": {
+								"from2": {
+									"version": "1.3.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"inherits": "~2.0.1",
+										"readable-stream": "~1.1.10"
+									},
+									"dependencies": {
+										"readable-stream": {
+											"version": "1.1.14",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"core-util-is": "~1.0.0",
+												"inherits": "~2.0.1",
+												"isarray": "0.0.1",
+												"string_decoder": "~0.10.x"
+											},
+											"dependencies": {
+												"core-util-is": {
+													"version": "1.0.2",
+													"bundled": true,
+													"dev": true
+												},
+												"isarray": {
+													"version": "0.0.1",
+													"bundled": true,
+													"dev": true
+												},
+												"string_decoder": {
+													"version": "0.10.31",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										}
+									}
+								},
+								"stream-iterate": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"readable-stream": "^2.1.5",
+										"stream-shift": "^1.0.0"
+									},
+									"dependencies": {
+										"stream-shift": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								}
+							}
+						},
+						"ssri": {
+							"version": "4.1.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							},
+							"dependencies": {
+								"ansi-regex": {
+									"version": "3.0.0",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"tar": {
+							"version": "2.2.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"block-stream": "*",
+								"fstream": "^1.0.2",
+								"inherits": "2"
+							},
+							"dependencies": {
+								"block-stream": {
+									"version": "0.0.9",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"inherits": "~2.0.0"
+									}
+								}
+							}
+						},
+						"text-table": {
+							"version": "0.2.0",
+							"bundled": true,
+							"dev": true
+						},
+						"uid-number": {
+							"version": "0.0.6",
+							"bundled": true,
+							"dev": true
+						},
+						"umask": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"unique-filename": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"unique-slug": "^2.0.0"
+							},
+							"dependencies": {
+								"unique-slug": {
+									"version": "2.0.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"imurmurhash": "^0.1.4"
+									}
+								}
+							}
+						},
+						"unpipe": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"update-notifier": {
+							"version": "2.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"boxen": "^1.0.0",
+								"chalk": "^1.0.0",
+								"configstore": "^3.0.0",
+								"import-lazy": "^2.1.0",
+								"is-npm": "^1.0.0",
+								"latest-version": "^3.0.0",
+								"semver-diff": "^2.0.0",
+								"xdg-basedir": "^3.0.0"
+							},
+							"dependencies": {
+								"boxen": {
+									"version": "1.1.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"ansi-align": "^2.0.0",
+										"camelcase": "^4.0.0",
+										"chalk": "^1.1.1",
+										"cli-boxes": "^1.0.0",
+										"string-width": "^2.0.0",
+										"term-size": "^0.1.0",
+										"widest-line": "^1.0.0"
+									},
+									"dependencies": {
+										"ansi-align": {
+											"version": "2.0.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"string-width": "^2.0.0"
+											}
+										},
+										"camelcase": {
+											"version": "4.1.0",
+											"bundled": true,
+											"dev": true
+										},
+										"cli-boxes": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true
+										},
+										"string-width": {
+											"version": "2.1.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"is-fullwidth-code-point": "^2.0.0",
+												"strip-ansi": "^4.0.0"
+											},
+											"dependencies": {
+												"is-fullwidth-code-point": {
+													"version": "2.0.0",
+													"bundled": true,
+													"dev": true
+												},
+												"strip-ansi": {
+													"version": "4.0.0",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"ansi-regex": "^3.0.0"
+													}
+												}
+											}
+										},
+										"term-size": {
+											"version": "0.1.1",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"execa": "^0.4.0"
+											},
+											"dependencies": {
+												"execa": {
+													"version": "0.4.0",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"cross-spawn-async": "^2.1.1",
+														"is-stream": "^1.1.0",
+														"npm-run-path": "^1.0.0",
+														"object-assign": "^4.0.1",
+														"path-key": "^1.0.0",
+														"strip-eof": "^1.0.0"
+													},
+													"dependencies": {
+														"cross-spawn-async": {
+															"version": "2.2.5",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"lru-cache": "^4.0.0",
+																"which": "^1.2.8"
+															}
+														},
+														"is-stream": {
+															"version": "1.1.0",
+															"bundled": true,
+															"dev": true
+														},
+														"npm-run-path": {
+															"version": "1.0.0",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"path-key": "^1.0.0"
+															}
+														},
+														"object-assign": {
+															"version": "4.1.1",
+															"bundled": true,
+															"dev": true
+														},
+														"path-key": {
+															"version": "1.0.0",
+															"bundled": true,
+															"dev": true
+														},
+														"strip-eof": {
+															"version": "1.0.0",
+															"bundled": true,
+															"dev": true
+														}
+													}
+												}
+											}
+										},
+										"widest-line": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"string-width": "^1.0.1"
+											},
+											"dependencies": {
+												"string-width": {
+													"version": "1.0.2",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"code-point-at": "^1.0.0",
+														"is-fullwidth-code-point": "^1.0.0",
+														"strip-ansi": "^3.0.0"
+													},
+													"dependencies": {
+														"code-point-at": {
+															"version": "1.1.0",
+															"bundled": true,
+															"dev": true
+														},
+														"is-fullwidth-code-point": {
+															"version": "1.0.0",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"number-is-nan": "^1.0.0"
+															},
+															"dependencies": {
+																"number-is-nan": {
+																	"version": "1.0.1",
+																	"bundled": true,
+																	"dev": true
+																}
+															}
+														},
+														"strip-ansi": {
+															"version": "3.0.1",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"ansi-regex": "^2.0.0"
+															},
+															"dependencies": {
+																"ansi-regex": {
+																	"version": "2.1.1",
+																	"bundled": true,
+																	"dev": true
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"chalk": {
+									"version": "1.1.3",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"ansi-styles": "^2.2.1",
+										"escape-string-regexp": "^1.0.2",
+										"has-ansi": "^2.0.0",
+										"strip-ansi": "^3.0.0",
+										"supports-color": "^2.0.0"
+									},
+									"dependencies": {
+										"ansi-styles": {
+											"version": "2.2.1",
+											"bundled": true,
+											"dev": true
+										},
+										"escape-string-regexp": {
+											"version": "1.0.5",
+											"bundled": true,
+											"dev": true
+										},
+										"has-ansi": {
+											"version": "2.0.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"ansi-regex": "^2.0.0"
+											},
+											"dependencies": {
+												"ansi-regex": {
+													"version": "2.1.1",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										},
+										"strip-ansi": {
+											"version": "3.0.1",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"ansi-regex": "^2.0.0"
+											},
+											"dependencies": {
+												"ansi-regex": {
+													"version": "2.1.1",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										},
+										"supports-color": {
+											"version": "2.0.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"configstore": {
+									"version": "3.1.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"dot-prop": "^4.1.0",
+										"graceful-fs": "^4.1.2",
+										"make-dir": "^1.0.0",
+										"unique-string": "^1.0.0",
+										"write-file-atomic": "^2.0.0",
+										"xdg-basedir": "^3.0.0"
+									},
+									"dependencies": {
+										"dot-prop": {
+											"version": "4.1.1",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"is-obj": "^1.0.0"
+											},
+											"dependencies": {
+												"is-obj": {
+													"version": "1.0.1",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										},
+										"make-dir": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"pify": "^2.3.0"
+											},
+											"dependencies": {
+												"pify": {
+													"version": "2.3.0",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										},
+										"unique-string": {
+											"version": "1.0.0",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"crypto-random-string": "^1.0.0"
+											},
+											"dependencies": {
+												"crypto-random-string": {
+													"version": "1.0.0",
+													"bundled": true,
+													"dev": true
+												}
+											}
+										}
+									}
+								},
+								"import-lazy": {
+									"version": "2.1.0",
+									"bundled": true,
+									"dev": true
+								},
+								"is-npm": {
+									"version": "1.0.0",
+									"bundled": true,
+									"dev": true
+								},
+								"latest-version": {
+									"version": "3.1.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"package-json": "^4.0.0"
+									},
+									"dependencies": {
+										"package-json": {
+											"version": "4.0.1",
+											"bundled": true,
+											"dev": true,
+											"requires": {
+												"got": "^6.7.1",
+												"registry-auth-token": "^3.0.1",
+												"registry-url": "^3.0.3",
+												"semver": "^5.1.0"
+											},
+											"dependencies": {
+												"got": {
+													"version": "6.7.1",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"create-error-class": "^3.0.0",
+														"duplexer3": "^0.1.4",
+														"get-stream": "^3.0.0",
+														"is-redirect": "^1.0.0",
+														"is-retry-allowed": "^1.0.0",
+														"is-stream": "^1.0.0",
+														"lowercase-keys": "^1.0.0",
+														"safe-buffer": "^5.0.1",
+														"timed-out": "^4.0.0",
+														"unzip-response": "^2.0.1",
+														"url-parse-lax": "^1.0.0"
+													},
+													"dependencies": {
+														"create-error-class": {
+															"version": "3.0.2",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"capture-stack-trace": "^1.0.0"
+															},
+															"dependencies": {
+																"capture-stack-trace": {
+																	"version": "1.0.0",
+																	"bundled": true,
+																	"dev": true
+																}
+															}
+														},
+														"duplexer3": {
+															"version": "0.1.4",
+															"bundled": true,
+															"dev": true
+														},
+														"get-stream": {
+															"version": "3.0.0",
+															"bundled": true,
+															"dev": true
+														},
+														"is-redirect": {
+															"version": "1.0.0",
+															"bundled": true,
+															"dev": true
+														},
+														"is-retry-allowed": {
+															"version": "1.1.0",
+															"bundled": true,
+															"dev": true
+														},
+														"is-stream": {
+															"version": "1.1.0",
+															"bundled": true,
+															"dev": true
+														},
+														"lowercase-keys": {
+															"version": "1.0.0",
+															"bundled": true,
+															"dev": true
+														},
+														"timed-out": {
+															"version": "4.0.1",
+															"bundled": true,
+															"dev": true
+														},
+														"unzip-response": {
+															"version": "2.0.1",
+															"bundled": true,
+															"dev": true
+														},
+														"url-parse-lax": {
+															"version": "1.0.0",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"prepend-http": "^1.0.1"
+															},
+															"dependencies": {
+																"prepend-http": {
+																	"version": "1.0.4",
+																	"bundled": true,
+																	"dev": true
+																}
+															}
+														}
+													}
+												},
+												"registry-auth-token": {
+													"version": "3.3.1",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"rc": "^1.1.6",
+														"safe-buffer": "^5.0.1"
+													},
+													"dependencies": {
+														"rc": {
+															"version": "1.2.1",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"deep-extend": "~0.4.0",
+																"ini": "~1.3.0",
+																"minimist": "^1.2.0",
+																"strip-json-comments": "~2.0.1"
+															},
+															"dependencies": {
+																"deep-extend": {
+																	"version": "0.4.2",
+																	"bundled": true,
+																	"dev": true
+																},
+																"minimist": {
+																	"version": "1.2.0",
+																	"bundled": true,
+																	"dev": true
+																},
+																"strip-json-comments": {
+																	"version": "2.0.1",
+																	"bundled": true,
+																	"dev": true
+																}
+															}
+														}
+													}
+												},
+												"registry-url": {
+													"version": "3.1.0",
+													"bundled": true,
+													"dev": true,
+													"requires": {
+														"rc": "^1.0.1"
+													},
+													"dependencies": {
+														"rc": {
+															"version": "1.2.1",
+															"bundled": true,
+															"dev": true,
+															"requires": {
+																"deep-extend": "~0.4.0",
+																"ini": "~1.3.0",
+																"minimist": "^1.2.0",
+																"strip-json-comments": "~2.0.1"
+															},
+															"dependencies": {
+																"deep-extend": {
+																	"version": "0.4.2",
+																	"bundled": true,
+																	"dev": true
+																},
+																"minimist": {
+																	"version": "1.2.0",
+																	"bundled": true,
+																	"dev": true
+																},
+																"strip-json-comments": {
+																	"version": "2.0.1",
+																	"bundled": true,
+																	"dev": true
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"semver-diff": {
+									"version": "2.1.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"semver": "^5.0.3"
+									}
+								},
+								"xdg-basedir": {
+									"version": "3.0.0",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"uuid": {
+							"version": "3.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"validate-npm-package-license": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"spdx-correct": "~1.0.0",
+								"spdx-expression-parse": "~1.0.0"
+							},
+							"dependencies": {
+								"spdx-correct": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"spdx-license-ids": "^1.0.2"
+									},
+									"dependencies": {
+										"spdx-license-ids": {
+											"version": "1.2.2",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"spdx-expression-parse": {
+									"version": "1.0.4",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"validate-npm-package-name": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"builtins": "^1.0.3"
+							},
+							"dependencies": {
+								"builtins": {
+									"version": "1.0.3",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"which": {
+							"version": "1.2.14",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							},
+							"dependencies": {
+								"isexe": {
+									"version": "2.0.0",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"worker-farm": {
+							"version": "1.3.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"errno": ">=0.1.1 <0.2.0-0",
+								"xtend": ">=4.0.0 <4.1.0-0"
+							},
+							"dependencies": {
+								"errno": {
+									"version": "0.1.4",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"prr": "~0.0.0"
+									},
+									"dependencies": {
+										"prr": {
+											"version": "0.0.0",
+											"bundled": true,
+											"dev": true
+										}
+									}
+								},
+								"xtend": {
+									"version": "4.0.1",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true
+						},
+						"write-file-atomic": {
+							"version": "2.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.1.11",
+								"imurmurhash": "^0.1.4",
+								"slide": "^1.1.5"
+							}
+						}
+					}
+				},
 				"q": {
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
@@ -6582,21 +9482,34 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
-			"integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
+			"version": "4.7.6",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+			"integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
 			"dev": true,
 			"requires": {
+				"minimist": "^1.2.5",
 				"neo-async": "^2.6.0",
-				"optimist": "^0.6.1",
 				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 					"dev": true
 				}
 			}
@@ -7052,6 +9965,12 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
+		},
+		"invert-kv": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+			"dev": true
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -7598,32 +10517,6 @@
 						"repeat-element": "^1.1.2"
 					}
 				},
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"execa": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -7650,18 +10543,6 @@
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
-				},
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
@@ -7737,15 +10618,6 @@
 						"is-buffer": "^1.1.5"
 					}
 				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"dev": true,
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
 				"locate-path": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -7754,15 +10626,6 @@
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
-					}
-				},
-				"mem": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^1.0.0"
 					}
 				},
 				"micromatch": {
@@ -7784,17 +10647,6 @@
 						"object.omit": "^2.0.0",
 						"parse-glob": "^3.0.4",
 						"regex-cache": "^0.4.2"
-					}
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"dev": true,
-					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
 					}
 				},
 				"p-limit": {
@@ -7847,16 +10699,16 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+					"version": "11.1.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz",
+					"integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
 					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
 						"find-up": "^2.1.0",
 						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
+						"os-locale": "^3.1.0",
 						"require-directory": "^2.1.1",
 						"require-main-filename": "^1.0.1",
 						"set-blocking": "^2.0.0",
@@ -7864,6 +10716,25 @@
 						"which-module": "^2.0.0",
 						"y18n": "^3.2.1",
 						"yargs-parser": "^9.0.2"
+					},
+					"dependencies": {
+						"cliui": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+							"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+							"dev": true,
+							"requires": {
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
+							}
+						},
+						"get-caller-file": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+							"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+							"dev": true
+						}
 					}
 				},
 				"yargs-parser": {
@@ -8441,32 +11312,6 @@
 						"repeat-element": "^1.1.2"
 					}
 				},
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"execa": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -8493,18 +11338,6 @@
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
-				},
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
@@ -8536,15 +11369,6 @@
 						"is-buffer": "^1.1.5"
 					}
 				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"dev": true,
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
 				"locate-path": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -8553,15 +11377,6 @@
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
-					}
-				},
-				"mem": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^1.0.0"
 					}
 				},
 				"micromatch": {
@@ -8583,17 +11398,6 @@
 						"object.omit": "^2.0.0",
 						"parse-glob": "^3.0.4",
 						"regex-cache": "^0.4.2"
-					}
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"dev": true,
-					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
 					}
 				},
 				"p-limit": {
@@ -8646,16 +11450,16 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+					"version": "11.1.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz",
+					"integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
 					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
 						"find-up": "^2.1.0",
 						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
+						"os-locale": "^3.1.0",
 						"require-directory": "^2.1.1",
 						"require-main-filename": "^1.0.1",
 						"set-blocking": "^2.0.0",
@@ -8663,6 +11467,25 @@
 						"which-module": "^2.0.0",
 						"y18n": "^3.2.1",
 						"yargs-parser": "^9.0.2"
+					},
+					"dependencies": {
+						"cliui": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+							"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+							"dev": true,
+							"requires": {
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
+							}
+						},
+						"get-caller-file": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+							"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+							"dev": true
+						}
 					}
 				},
 				"yargs-parser": {
@@ -8907,9 +11730,9 @@
 			}
 		},
 		"kind-of": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true
 		},
 		"kleur": {
@@ -8917,6 +11740,15 @@
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
 			"integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
 			"dev": true
+		},
+		"lcid": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+			"dev": true,
+			"requires": {
+				"invert-kv": "^2.0.0"
+			}
 		},
 		"lcov-parse": {
 			"version": "1.0.0",
@@ -9328,16 +12160,6 @@
 				"signal-exit": "^3.0.0"
 			}
 		},
-		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"dev": true,
-			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
-			}
-		},
 		"macos-release": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
@@ -9398,6 +12220,15 @@
 				"tmpl": "1.0.x"
 			}
 		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"dev": true,
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -9434,6 +12265,25 @@
 			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
 			"dev": true
 		},
+		"mem": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+			"dev": true,
+			"requires": {
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				}
+			}
+		},
 		"meow": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
@@ -9452,9 +12302,9 @@
 			},
 			"dependencies": {
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				}
 			}
@@ -9614,12 +12464,20 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				}
 			}
 		},
 		"mkdirp-promise": {
@@ -9687,9 +12545,9 @@
 			}
 		},
 		"nan": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"dev": true,
 			"optional": true
 		},
@@ -9882,45 +12740,63 @@
 			"dev": true
 		},
 		"npm": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-5.1.0.tgz",
-			"integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
+			"version": "6.14.4",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-6.14.4.tgz",
+			"integrity": "sha512-B8UDDbWvdkW6RgXFn8/h2cHJP/u/FPa4HWeGzW23aNEBARN3QPrRaHqPIZW2NSN3fW649gtgUDNZpaRs0zTMPw==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "~1.3.1",
-				"abbrev": "~1.1.0",
-				"ansi-regex": "~3.0.0",
+				"JSONStream": "^1.3.5",
+				"abbrev": "~1.1.1",
 				"ansicolors": "~0.3.2",
 				"ansistyles": "~0.1.3",
-				"aproba": "~1.1.2",
+				"aproba": "^2.0.0",
 				"archy": "~1.0.0",
-				"bluebird": "~3.5.0",
-				"cacache": "~9.2.9",
-				"call-limit": "~1.1.0",
-				"chownr": "~1.0.1",
-				"cmd-shim": "~2.0.2",
+				"bin-links": "^1.1.7",
+				"bluebird": "^3.5.5",
+				"byte-size": "^5.0.1",
+				"cacache": "^12.0.3",
+				"call-limit": "^1.1.1",
+				"chownr": "^1.1.4",
+				"ci-info": "^2.0.0",
+				"cli-columns": "^3.1.2",
+				"cli-table3": "^0.5.1",
+				"cmd-shim": "^3.0.3",
 				"columnify": "~1.5.4",
-				"config-chain": "~1.1.11",
+				"config-chain": "^1.1.12",
 				"debuglog": "*",
 				"detect-indent": "~5.0.0",
+				"detect-newline": "^2.1.0",
 				"dezalgo": "~1.0.3",
 				"editor": "~1.0.0",
+				"figgy-pudding": "^3.5.1",
+				"find-npm-prefix": "^1.0.2",
 				"fs-vacuum": "~1.2.10",
 				"fs-write-stream-atomic": "~1.0.10",
-				"fstream": "~1.0.11",
-				"fstream-npm": "~1.2.1",
-				"glob": "~7.1.2",
-				"graceful-fs": "~4.1.11",
+				"gentle-fs": "^2.3.0",
+				"glob": "^7.1.6",
+				"graceful-fs": "^4.2.3",
 				"has-unicode": "~2.0.1",
-				"hosted-git-info": "~2.5.0",
-				"iferr": "~0.1.5",
+				"hosted-git-info": "^2.8.8",
+				"iferr": "^1.0.2",
 				"imurmurhash": "*",
+				"infer-owner": "^1.0.4",
 				"inflight": "~1.0.6",
-				"inherits": "~2.0.3",
-				"ini": "~1.3.4",
-				"init-package-json": "~1.10.1",
+				"inherits": "^2.0.4",
+				"ini": "^1.3.5",
+				"init-package-json": "^1.10.3",
+				"is-cidr": "^3.0.0",
+				"json-parse-better-errors": "^1.0.2",
 				"lazy-property": "~1.0.0",
-				"lockfile": "~1.0.3",
+				"libcipm": "^4.0.7",
+				"libnpm": "^3.0.1",
+				"libnpmaccess": "^3.0.2",
+				"libnpmhook": "^5.0.3",
+				"libnpmorg": "^1.0.1",
+				"libnpmsearch": "^2.0.2",
+				"libnpmteam": "^1.0.2",
+				"libnpx": "^10.2.2",
+				"lock-verify": "^2.1.0",
+				"lockfile": "^1.0.4",
 				"lodash._baseindexof": "*",
 				"lodash._baseuniq": "~4.6.0",
 				"lodash._bindcallback": "*",
@@ -9932,89 +12808,129 @@
 				"lodash.union": "~4.6.0",
 				"lodash.uniq": "~4.5.0",
 				"lodash.without": "~4.4.0",
-				"lru-cache": "~4.1.1",
-				"mississippi": "~1.3.0",
-				"mkdirp": "~0.5.1",
-				"move-concurrently": "~1.0.1",
-				"node-gyp": "~3.6.2",
+				"lru-cache": "^5.1.1",
+				"meant": "~1.0.1",
+				"mississippi": "^3.0.0",
+				"mkdirp": "^0.5.4",
+				"move-concurrently": "^1.0.1",
+				"node-gyp": "^5.1.0",
 				"nopt": "~4.0.1",
-				"normalize-package-data": "~2.4.0",
+				"normalize-package-data": "^2.5.0",
+				"npm-audit-report": "^1.3.2",
 				"npm-cache-filename": "~1.0.2",
-				"npm-install-checks": "~3.0.0",
-				"npm-package-arg": "~5.1.2",
-				"npm-registry-client": "~8.4.0",
+				"npm-install-checks": "^3.0.2",
+				"npm-lifecycle": "^3.1.4",
+				"npm-package-arg": "^6.1.1",
+				"npm-packlist": "^1.4.8",
+				"npm-pick-manifest": "^3.0.2",
+				"npm-profile": "^4.0.4",
+				"npm-registry-fetch": "^4.0.3",
 				"npm-user-validate": "~1.0.0",
 				"npmlog": "~4.1.2",
 				"once": "~1.4.0",
-				"opener": "~1.4.3",
-				"osenv": "~0.1.4",
-				"pacote": "~2.7.38",
+				"opener": "^1.5.1",
+				"osenv": "^0.1.5",
+				"pacote": "^9.5.12",
 				"path-is-inside": "~1.0.2",
 				"promise-inflight": "~1.0.1",
+				"qrcode-terminal": "^0.12.0",
+				"query-string": "^6.8.2",
+				"qw": "~1.0.1",
 				"read": "~1.0.7",
-				"read-cmd-shim": "~1.0.1",
+				"read-cmd-shim": "^1.0.5",
 				"read-installed": "~4.0.3",
-				"read-package-json": "~2.0.9",
-				"read-package-tree": "~5.1.6",
-				"readable-stream": "~2.3.2",
-				"readdir-scoped-modules": "*",
-				"request": "~2.81.0",
-				"retry": "~0.10.1",
-				"rimraf": "~2.6.1",
-				"safe-buffer": "~5.1.1",
-				"semver": "~5.3.0",
-				"sha": "~2.0.1",
+				"read-package-json": "^2.1.1",
+				"read-package-tree": "^5.3.1",
+				"readable-stream": "^3.6.0",
+				"readdir-scoped-modules": "^1.1.0",
+				"request": "^2.88.0",
+				"retry": "^0.12.0",
+				"rimraf": "^2.7.1",
+				"safe-buffer": "^5.1.2",
+				"semver": "^5.7.1",
+				"sha": "^3.0.0",
 				"slide": "~1.1.6",
 				"sorted-object": "~2.0.1",
 				"sorted-union-stream": "~2.1.3",
-				"ssri": "~4.1.6",
-				"strip-ansi": "~4.0.0",
-				"tar": "~2.2.1",
+				"ssri": "^6.0.1",
+				"stringify-package": "^1.0.1",
+				"tar": "^4.4.13",
 				"text-table": "~0.2.0",
+				"tiny-relative-date": "^1.3.0",
 				"uid-number": "0.0.6",
 				"umask": "~1.1.0",
-				"unique-filename": "~1.1.0",
+				"unique-filename": "^1.1.1",
 				"unpipe": "~1.0.0",
-				"update-notifier": "~2.2.0",
-				"uuid": "~3.1.0",
-				"validate-npm-package-license": "*",
+				"update-notifier": "^2.5.0",
+				"uuid": "^3.3.3",
+				"validate-npm-package-license": "^3.0.4",
 				"validate-npm-package-name": "~3.0.0",
-				"which": "~1.2.14",
-				"worker-farm": "~1.3.1",
-				"wrappy": "~1.0.2",
-				"write-file-atomic": "~2.1.0"
+				"which": "^1.3.1",
+				"worker-farm": "^1.7.0",
+				"write-file-atomic": "^2.4.3"
 			},
 			"dependencies": {
 				"JSONStream": {
-					"version": "1.3.1",
+					"version": "1.3.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"jsonparse": "^1.2.0",
 						"through": ">=2.2.7 <3"
-					},
-					"dependencies": {
-						"jsonparse": {
-							"version": "1.3.1",
-							"bundled": true,
-							"dev": true
-						},
-						"through": {
-							"version": "2.3.8",
-							"bundled": true,
-							"dev": true
-						}
 					}
 				},
 				"abbrev": {
-					"version": "1.1.0",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true
 				},
+				"agent-base": {
+					"version": "4.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
+				"agentkeepalive": {
+					"version": "3.5.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"humanize-ms": "^1.2.1"
+					}
+				},
+				"ajv": {
+					"version": "5.5.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
+					}
+				},
+				"ansi-align": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "^2.0.0"
+					}
+				},
 				"ansi-regex": {
-					"version": "3.0.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
 				},
 				"ansicolors": {
 					"version": "0.3.2",
@@ -10027,7 +12943,7 @@
 					"dev": true
 				},
 				"aproba": {
-					"version": "1.1.2",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -10036,77 +12952,308 @@
 					"bundled": true,
 					"dev": true
 				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"asap": {
+					"version": "2.0.6",
+					"bundled": true,
+					"dev": true
+				},
+				"asn1": {
+					"version": "0.2.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safer-buffer": "~2.1.0"
+					}
+				},
+				"assert-plus": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"dev": true
+				},
+				"aws-sign2": {
+					"version": "0.7.0",
+					"bundled": true,
+					"dev": true
+				},
+				"aws4": {
+					"version": "1.8.0",
+					"bundled": true,
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "^0.14.3"
+					}
+				},
+				"bin-links": {
+					"version": "1.1.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"bluebird": "^3.5.3",
+						"cmd-shim": "^3.0.0",
+						"gentle-fs": "^2.3.0",
+						"graceful-fs": "^4.1.15",
+						"npm-normalize-package-bin": "^1.0.0",
+						"write-file-atomic": "^2.3.0"
+					}
+				},
 				"bluebird": {
-					"version": "3.5.0",
+					"version": "3.5.5",
+					"bundled": true,
+					"dev": true
+				},
+				"boxen": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-align": "^2.0.0",
+						"camelcase": "^4.0.0",
+						"chalk": "^2.0.1",
+						"cli-boxes": "^1.0.0",
+						"string-width": "^2.0.0",
+						"term-size": "^1.2.0",
+						"widest-line": "^2.0.0"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-from": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"builtins": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"byline": {
+					"version": "5.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"byte-size": {
+					"version": "5.0.1",
 					"bundled": true,
 					"dev": true
 				},
 				"cacache": {
-					"version": "9.2.9",
+					"version": "12.0.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.0",
-						"chownr": "^1.0.1",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"lru-cache": "^4.1.1",
-						"mississippi": "^1.3.0",
+						"bluebird": "^3.5.5",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.1.15",
+						"infer-owner": "^1.0.3",
+						"lru-cache": "^5.1.1",
+						"mississippi": "^3.0.0",
 						"mkdirp": "^0.5.1",
 						"move-concurrently": "^1.0.1",
 						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.1",
-						"ssri": "^4.1.6",
-						"unique-filename": "^1.1.0",
-						"y18n": "^3.2.1"
-					},
-					"dependencies": {
-						"lru-cache": {
-							"version": "4.1.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"pseudomap": "^1.0.2",
-								"yallist": "^2.1.2"
-							},
-							"dependencies": {
-								"pseudomap": {
-									"version": "1.0.2",
-									"bundled": true,
-									"dev": true
-								},
-								"yallist": {
-									"version": "2.1.2",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"y18n": {
-							"version": "3.2.1",
-							"bundled": true,
-							"dev": true
-						}
+						"rimraf": "^2.6.3",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
+						"y18n": "^4.0.0"
 					}
 				},
 				"call-limit": {
-					"version": "1.1.0",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true
 				},
+				"camelcase": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"capture-stack-trace": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.4",
+					"bundled": true,
+					"dev": true
+				},
+				"ci-info": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"cidr-regex": {
+					"version": "2.0.10",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ip-regex": "^2.1.0"
+					}
+				},
+				"cli-boxes": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"cli-columns": {
+					"version": "3.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "^2.0.0",
+						"strip-ansi": "^3.0.1"
+					}
+				},
+				"cli-table3": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"colors": "^1.1.2",
+						"object-assign": "^4.1.0",
+						"string-width": "^2.1.1"
+					}
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"clone": {
+					"version": "1.0.4",
 					"bundled": true,
 					"dev": true
 				},
 				"cmd-shim": {
-					"version": "2.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"mkdirp": "~0.5.0"
 					}
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"dev": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"color-convert": {
+					"version": "1.9.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"color-name": "^1.1.1"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true
+				},
+				"colors": {
+					"version": "1.3.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
 				},
 				"columnify": {
 					"version": "1.5.4",
@@ -10115,72 +13262,178 @@
 					"requires": {
 						"strip-ansi": "^3.0.0",
 						"wcwidth": "^1.0.0"
+					}
+				},
+				"combined-stream": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"delayed-stream": "~1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"concat-stream": {
+					"version": "1.6.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
 					},
 					"dependencies": {
-						"strip-ansi": {
-							"version": "3.0.1",
+						"readable-stream": {
+							"version": "2.3.6",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^2.0.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "2.1.1",
-									"bundled": true,
-									"dev": true
-								}
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
 							}
 						},
-						"wcwidth": {
-							"version": "1.0.1",
+						"string_decoder": {
+							"version": "1.1.1",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"defaults": "^1.0.3"
-							},
-							"dependencies": {
-								"defaults": {
-									"version": "1.0.3",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"clone": "^1.0.2"
-									},
-									"dependencies": {
-										"clone": {
-											"version": "1.0.2",
-											"bundled": true,
-											"dev": true
-										}
-									}
-								}
+								"safe-buffer": "~5.1.0"
 							}
 						}
 					}
 				},
 				"config-chain": {
-					"version": "1.1.11",
+					"version": "1.1.12",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ini": "^1.3.4",
 						"proto-list": "~1.2.1"
+					}
+				},
+				"configstore": {
+					"version": "3.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"unique-string": "^1.0.0",
+						"write-file-atomic": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					}
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"copy-concurrently": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^1.1.1",
+						"fs-write-stream-atomic": "^1.0.8",
+						"iferr": "^0.1.5",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.0"
 					},
 					"dependencies": {
-						"proto-list": {
-							"version": "1.2.4",
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
+						"iferr": {
+							"version": "0.1.5",
 							"bundled": true,
 							"dev": true
 						}
 					}
 				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"create-error-class": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"capture-stack-trace": "^1.0.0"
+					}
+				},
+				"cross-spawn": {
+					"version": "5.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "4.1.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
+							}
+						},
+						"yallist": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"crypto-random-string": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"cyclist": {
+					"version": "0.2.2",
+					"bundled": true,
+					"dev": true
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"debuglog": {
@@ -10188,8 +13441,54 @@
 					"bundled": true,
 					"dev": true
 				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"deep-extend": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true
+				},
+				"defaults": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"clone": "^1.0.2"
+					}
+				},
+				"define-properties": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"object-keys": "^1.0.12"
+					}
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
 				"detect-indent": {
 					"version": "5.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"detect-newline": {
+					"version": "2.1.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -10200,19 +13499,308 @@
 					"requires": {
 						"asap": "^2.0.0",
 						"wrappy": "1"
+					}
+				},
+				"dot-prop": {
+					"version": "4.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				},
+				"dotenv": {
+					"version": "5.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"duplexer3": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true
+				},
+				"duplexify": {
+					"version": "3.6.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.0.0",
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0",
+						"stream-shift": "^1.0.0"
 					},
 					"dependencies": {
-						"asap": {
-							"version": "2.0.5",
+						"readable-stream": {
+							"version": "2.3.6",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
 						}
+					}
+				},
+				"ecc-jsbn": {
+					"version": "0.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "~0.1.0",
+						"safer-buffer": "^2.1.0"
 					}
 				},
 				"editor": {
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"iconv-lite": "~0.4.13"
+					}
+				},
+				"end-of-stream": {
+					"version": "1.4.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "^1.4.0"
+					}
+				},
+				"env-paths": {
+					"version": "2.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"err-code": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"errno": {
+					"version": "0.1.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"prr": "~1.0.1"
+					}
+				},
+				"es-abstract": {
+					"version": "1.12.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.1.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.1",
+						"is-callable": "^1.1.3",
+						"is-regex": "^1.0.4"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"es6-promise": {
+					"version": "4.2.8",
+					"bundled": true,
+					"dev": true
+				},
+				"es6-promisify": {
+					"version": "5.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"es6-promise": "^4.0.3"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"extend": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"extsprintf": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true
+				},
+				"fast-deep-equal": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"fast-json-stable-stringify": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"figgy-pudding": {
+					"version": "3.5.1",
+					"bundled": true,
+					"dev": true
+				},
+				"find-npm-prefix": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"flush-write-stream": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.4"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"dev": true
+				},
+				"form-data": {
+					"version": "2.3.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"from2": {
+					"version": "2.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"fs-minipass": {
+					"version": "1.2.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minipass": "^2.6.0"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						}
+					}
 				},
 				"fs-vacuum": {
 					"version": "1.2.10",
@@ -10233,41 +13821,137 @@
 						"iferr": "^0.1.5",
 						"imurmurhash": "^0.1.4",
 						"readable-stream": "1 || 2"
-					}
-				},
-				"fstream-npm": {
-					"version": "1.2.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"fstream-ignore": "^1.0.0",
-						"inherits": "2"
 					},
 					"dependencies": {
-						"fstream-ignore": {
-							"version": "1.0.5",
+						"iferr": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.6",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"fstream": "^1.0.0",
-								"inherits": "2",
-								"minimatch": "^3.0.0"
-							},
-							"dependencies": {
-								"minimatch": {
-									"version": "3.0.4",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"brace-expansion": "^1.1.7"
-									}
-								}
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
 							}
 						}
 					}
 				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"function-bind": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"genfun": {
+					"version": "5.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"gentle-fs": {
+					"version": "2.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^1.1.2",
+						"chownr": "^1.1.2",
+						"cmd-shim": "^3.0.3",
+						"fs-vacuum": "^1.2.10",
+						"graceful-fs": "^4.1.11",
+						"iferr": "^0.1.5",
+						"infer-owner": "^1.0.4",
+						"mkdirp": "^0.5.1",
+						"path-is-inside": "^1.0.2",
+						"read-cmd-shim": "^1.0.1",
+						"slide": "^1.1.6"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
+						"iferr": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"get-caller-file": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -10277,30 +13961,75 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"global-dirs": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ini": "^1.3.4"
+					}
+				},
+				"got": {
+					"version": "6.7.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"create-error-class": "^3.0.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-redirect": "^1.0.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"lowercase-keys": "^1.0.0",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"unzip-response": "^2.0.1",
+						"url-parse-lax": "^1.0.0"
 					},
 					"dependencies": {
-						"fs.realpath": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"minimatch": {
-							"version": "3.0.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						},
-						"path-is-absolute": {
-							"version": "1.0.1",
+						"get-stream": {
+							"version": "3.0.0",
 							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"graceful-fs": {
-					"version": "4.1.11",
+					"version": "4.2.3",
+					"bundled": true,
+					"dev": true
+				},
+				"har-schema": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"har-validator": {
+					"version": "5.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ajv": "^5.3.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"has": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"has-symbols": {
+					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -10310,17 +14039,84 @@
 					"dev": true
 				},
 				"hosted-git-info": {
-					"version": "2.5.0",
+					"version": "2.8.8",
 					"bundled": true,
 					"dev": true
 				},
+				"http-cache-semantics": {
+					"version": "3.8.1",
+					"bundled": true,
+					"dev": true
+				},
+				"http-proxy-agent": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"agent-base": "4",
+						"debug": "3.1.0"
+					}
+				},
+				"http-signature": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "2.2.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"agent-base": "^4.3.0",
+						"debug": "^3.1.0"
+					}
+				},
+				"humanize-ms": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ms": "^2.0.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.23",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
 				"iferr": {
-					"version": "0.1.5",
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"ignore-walk": {
+					"version": "3.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimatch": "^3.0.4"
+					}
+				},
+				"import-lazy": {
+					"version": "2.1.0",
 					"bundled": true,
 					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
+					"bundled": true,
+					"dev": true
+				},
+				"infer-owner": {
+					"version": "1.0.4",
 					"bundled": true,
 					"dev": true
 				},
@@ -10334,38 +14130,212 @@
 					}
 				},
 				"inherits": {
-					"version": "2.0.3",
+					"version": "2.0.4",
 					"bundled": true,
 					"dev": true
 				},
 				"ini": {
-					"version": "1.3.4",
+					"version": "1.3.5",
 					"bundled": true,
 					"dev": true
 				},
 				"init-package-json": {
-					"version": "1.10.1",
+					"version": "1.10.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
-						"npm-package-arg": "^4.0.0 || ^5.0.0",
+						"npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
 						"promzard": "^0.3.0",
 						"read": "~1.0.1",
 						"read-package-json": "1 || 2",
 						"semver": "2.x || 3.x || 4 || 5",
 						"validate-npm-package-license": "^3.0.1",
 						"validate-npm-package-name": "^3.0.0"
+					}
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"ip": {
+					"version": "1.1.5",
+					"bundled": true,
+					"dev": true
+				},
+				"ip-regex": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.4",
+					"bundled": true,
+					"dev": true
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ci-info": "^1.5.0"
 					},
 					"dependencies": {
-						"promzard": {
-							"version": "0.3.0",
+						"ci-info": {
+							"version": "1.6.0",
 							"bundled": true,
-							"dev": true,
-							"requires": {
-								"read": "1"
-							}
+							"dev": true
 						}
+					}
+				},
+				"is-cidr": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cidr-regex": "^2.0.10"
+					}
+				},
+				"is-date-object": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"is-installed-globally": {
+					"version": "0.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"global-dirs": "^0.1.0",
+						"is-path-inside": "^1.0.0"
+					}
+				},
+				"is-npm": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-obj": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-path-inside": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"path-is-inside": "^1.0.1"
+					}
+				},
+				"is-redirect": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"has": "^1.0.1"
+					}
+				},
+				"is-retry-allowed": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-symbol": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"has-symbols": "^1.0.0"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"json-parse-better-errors": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"dev": true
+				},
+				"json-schema-traverse": {
+					"version": "0.3.1",
+					"bundled": true,
+					"dev": true
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"jsonparse": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true
+				},
+				"jsprim": {
+					"version": "1.4.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.3.0",
+						"json-schema": "0.2.3",
+						"verror": "1.10.0"
+					}
+				},
+				"latest-version": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"package-json": "^4.0.0"
 					}
 				},
 				"lazy-property": {
@@ -10373,10 +14343,223 @@
 					"bundled": true,
 					"dev": true
 				},
-				"lockfile": {
-					"version": "1.0.3",
+				"lcid": {
+					"version": "2.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"invert-kv": "^2.0.0"
+					}
+				},
+				"libcipm": {
+					"version": "4.0.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"bin-links": "^1.1.2",
+						"bluebird": "^3.5.1",
+						"figgy-pudding": "^3.5.1",
+						"find-npm-prefix": "^1.0.2",
+						"graceful-fs": "^4.1.11",
+						"ini": "^1.3.5",
+						"lock-verify": "^2.0.2",
+						"mkdirp": "^0.5.1",
+						"npm-lifecycle": "^3.0.0",
+						"npm-logical-tree": "^1.2.1",
+						"npm-package-arg": "^6.1.0",
+						"pacote": "^9.1.0",
+						"read-package-json": "^2.0.13",
+						"rimraf": "^2.6.2",
+						"worker-farm": "^1.6.0"
+					}
+				},
+				"libnpm": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"bin-links": "^1.1.2",
+						"bluebird": "^3.5.3",
+						"find-npm-prefix": "^1.0.2",
+						"libnpmaccess": "^3.0.2",
+						"libnpmconfig": "^1.2.1",
+						"libnpmhook": "^5.0.3",
+						"libnpmorg": "^1.0.1",
+						"libnpmpublish": "^1.1.2",
+						"libnpmsearch": "^2.0.2",
+						"libnpmteam": "^1.0.2",
+						"lock-verify": "^2.0.2",
+						"npm-lifecycle": "^3.0.0",
+						"npm-logical-tree": "^1.2.1",
+						"npm-package-arg": "^6.1.0",
+						"npm-profile": "^4.0.2",
+						"npm-registry-fetch": "^4.0.0",
+						"npmlog": "^4.1.2",
+						"pacote": "^9.5.3",
+						"read-package-json": "^2.0.13",
+						"stringify-package": "^1.0.0"
+					}
+				},
+				"libnpmaccess": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"get-stream": "^4.0.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpmconfig": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"find-up": "^3.0.0",
+						"ini": "^1.3.5"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"locate-path": "^3.0.0"
+							}
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "2.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-try": "^2.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"p-try": {
+							"version": "2.2.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"libnpmhook": {
+					"version": "5.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpmorg": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpmpublish": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.0.0",
+						"lodash.clonedeep": "^4.5.0",
+						"normalize-package-data": "^2.4.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-registry-fetch": "^4.0.0",
+						"semver": "^5.5.1",
+						"ssri": "^6.0.1"
+					}
+				},
+				"libnpmsearch": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpmteam": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpx": {
+					"version": "10.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"dotenv": "^5.0.1",
+						"npm-package-arg": "^6.0.0",
+						"rimraf": "^2.6.2",
+						"safe-buffer": "^5.1.0",
+						"update-notifier": "^2.3.0",
+						"which": "^1.3.0",
+						"y18n": "^4.0.0",
+						"yargs": "^11.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lock-verify": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"npm-package-arg": "^6.1.0",
+						"semver": "^5.4.1"
+					}
+				},
+				"lockfile": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"signal-exit": "^3.0.2"
+					}
 				},
 				"lodash._baseindexof": {
 					"version": "3.1.0",
@@ -10390,18 +14573,6 @@
 					"requires": {
 						"lodash._createset": "~4.0.0",
 						"lodash._root": "~3.0.0"
-					},
-					"dependencies": {
-						"lodash._createset": {
-							"version": "4.0.3",
-							"bundled": true,
-							"dev": true
-						},
-						"lodash._root": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
-						}
 					}
 				},
 				"lodash._bindcallback": {
@@ -10422,8 +14593,18 @@
 						"lodash._getnative": "^3.0.0"
 					}
 				},
+				"lodash._createset": {
+					"version": "4.0.3",
+					"bundled": true,
+					"dev": true
+				},
 				"lodash._getnative": {
 					"version": "3.9.1",
+					"bundled": true,
+					"dev": true
+				},
+				"lodash._root": {
+					"version": "3.0.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -10452,29 +14633,117 @@
 					"bundled": true,
 					"dev": true
 				},
+				"lowercase-keys": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
 				"lru-cache": {
-					"version": "4.1.1",
+					"version": "5.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
+						"yallist": "^3.0.2"
+					}
+				},
+				"make-dir": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"make-fetch-happen": {
+					"version": "5.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"agentkeepalive": "^3.4.1",
+						"cacache": "^12.0.0",
+						"http-cache-semantics": "^3.8.1",
+						"http-proxy-agent": "^2.1.0",
+						"https-proxy-agent": "^2.2.3",
+						"lru-cache": "^5.1.1",
+						"mississippi": "^3.0.0",
+						"node-fetch-npm": "^2.0.2",
+						"promise-retry": "^1.1.1",
+						"socks-proxy-agent": "^4.0.0",
+						"ssri": "^6.0.0"
+					}
+				},
+				"map-age-cleaner": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-defer": "^1.0.0"
+					}
+				},
+				"meant": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"mem": {
+					"version": "4.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^2.0.0",
+						"p-is-promise": "^2.0.0"
 					},
 					"dependencies": {
-						"pseudomap": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"yallist": {
-							"version": "2.1.2",
+						"mimic-fn": {
+							"version": "2.1.0",
 							"bundled": true,
 							"dev": true
 						}
 					}
 				},
+				"mime-db": {
+					"version": "1.35.0",
+					"bundled": true,
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.19",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"mime-db": "~1.35.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minizlib": {
+					"version": "1.3.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minipass": "^2.9.0"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						}
+					}
+				},
 				"mississippi": {
-					"version": "1.3.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -10484,171 +14753,22 @@
 						"flush-write-stream": "^1.0.0",
 						"from2": "^2.1.0",
 						"parallel-transform": "^1.1.0",
-						"pump": "^1.0.0",
+						"pump": "^3.0.0",
 						"pumpify": "^1.3.3",
 						"stream-each": "^1.1.0",
 						"through2": "^2.0.0"
-					},
-					"dependencies": {
-						"concat-stream": {
-							"version": "1.6.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"readable-stream": "^2.2.2",
-								"typedarray": "^0.0.6"
-							},
-							"dependencies": {
-								"typedarray": {
-									"version": "0.0.6",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"duplexify": {
-							"version": "3.5.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"end-of-stream": "1.0.0",
-								"inherits": "^2.0.1",
-								"readable-stream": "^2.0.0",
-								"stream-shift": "^1.0.0"
-							},
-							"dependencies": {
-								"end-of-stream": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"once": "~1.3.0"
-									},
-									"dependencies": {
-										"once": {
-											"version": "1.3.3",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"wrappy": "1"
-											}
-										}
-									}
-								},
-								"stream-shift": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"end-of-stream": {
-							"version": "1.4.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"once": "^1.4.0"
-							}
-						},
-						"flush-write-stream": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.1",
-								"readable-stream": "^2.0.4"
-							}
-						},
-						"from2": {
-							"version": "2.3.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.1",
-								"readable-stream": "^2.0.0"
-							}
-						},
-						"parallel-transform": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"cyclist": "~0.2.2",
-								"inherits": "^2.0.3",
-								"readable-stream": "^2.1.5"
-							},
-							"dependencies": {
-								"cyclist": {
-									"version": "0.2.2",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"pump": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"end-of-stream": "^1.1.0",
-								"once": "^1.3.1"
-							}
-						},
-						"pumpify": {
-							"version": "1.3.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"duplexify": "^3.1.2",
-								"inherits": "^2.0.1",
-								"pump": "^1.0.0"
-							}
-						},
-						"stream-each": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"end-of-stream": "^1.1.0",
-								"stream-shift": "^1.0.0"
-							},
-							"dependencies": {
-								"stream-shift": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"through2": {
-							"version": "2.0.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"readable-stream": "^2.1.5",
-								"xtend": "~4.0.1"
-							},
-							"dependencies": {
-								"xtend": {
-									"version": "4.0.1",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						}
 					}
 				},
 				"mkdirp": {
-					"version": "0.5.1",
+					"version": "0.5.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minimist": "0.0.8"
+						"minimist": "^1.2.5"
 					},
 					"dependencies": {
 						"minimist": {
-							"version": "0.0.8",
+							"version": "1.2.5",
 							"bundled": true,
 							"dev": true
 						}
@@ -10667,70 +14787,54 @@
 						"run-queue": "^1.0.3"
 					},
 					"dependencies": {
-						"copy-concurrently": {
-							"version": "1.0.3",
+						"aproba": {
+							"version": "1.2.0",
 							"bundled": true,
-							"dev": true,
-							"requires": {
-								"aproba": "^1.1.1",
-								"fs-write-stream-atomic": "^1.0.8",
-								"iferr": "^0.1.5",
-								"mkdirp": "^0.5.1",
-								"rimraf": "^2.5.4",
-								"run-queue": "^1.0.0"
-							}
-						},
-						"run-queue": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"aproba": "^1.1.1"
-							}
+							"dev": true
 						}
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
 				},
-				"node-gyp": {
-					"version": "3.6.2",
+				"mute-stream": {
+					"version": "0.0.7",
+					"bundled": true,
+					"dev": true
+				},
+				"nice-try": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"node-fetch-npm": {
+					"version": "2.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fstream": "^1.0.0",
-						"glob": "^7.0.3",
-						"graceful-fs": "^4.1.2",
-						"minimatch": "^3.0.2",
-						"mkdirp": "^0.5.0",
-						"nopt": "2 || 3",
-						"npmlog": "0 || 1 || 2 || 3 || 4",
-						"osenv": "0",
-						"request": "2",
-						"rimraf": "2",
-						"semver": "~5.3.0",
-						"tar": "^2.0.0",
-						"which": "1"
-					},
-					"dependencies": {
-						"minimatch": {
-							"version": "3.0.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						},
-						"nopt": {
-							"version": "3.0.6",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"abbrev": "1"
-							}
-						}
+						"encoding": "^0.1.11",
+						"json-parse-better-errors": "^1.0.0",
+						"safe-buffer": "^5.1.1"
+					}
+				},
+				"node-gyp": {
+					"version": "5.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"env-paths": "^2.2.0",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.2.2",
+						"mkdirp": "^0.5.1",
+						"nopt": "^4.0.1",
+						"npmlog": "^4.1.2",
+						"request": "^2.88.0",
+						"rimraf": "^2.6.3",
+						"semver": "^5.7.1",
+						"tar": "^4.4.12",
+						"which": "^1.3.1"
 					}
 				},
 				"nopt": {
@@ -10743,31 +14847,41 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "2.4.0",
+					"version": "2.5.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
-						"is-builtin-module": "^1.0.0",
+						"resolve": "^1.10.0",
 						"semver": "2 || 3 || 4 || 5",
 						"validate-npm-package-license": "^3.0.1"
 					},
 					"dependencies": {
-						"is-builtin-module": {
-							"version": "1.0.0",
+						"resolve": {
+							"version": "1.10.0",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"builtin-modules": "^1.0.0"
-							},
-							"dependencies": {
-								"builtin-modules": {
-									"version": "1.1.1",
-									"bundled": true,
-									"dev": true
-								}
+								"path-parse": "^1.0.6"
 							}
 						}
+					}
+				},
+				"npm-audit-report": {
+					"version": "1.3.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cli-table3": "^0.5.0",
+						"console-control-strings": "^1.1.0"
+					}
+				},
+				"npm-bundled": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"npm-normalize-package-bin": "^1.0.1"
 					}
 				},
 				"npm-cache-filename": {
@@ -10776,59 +14890,106 @@
 					"dev": true
 				},
 				"npm-install-checks": {
-					"version": "3.0.0",
+					"version": "3.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"semver": "^2.3.0 || 3.x || 4 || 5"
 					}
 				},
-				"npm-package-arg": {
-					"version": "5.1.2",
+				"npm-lifecycle": {
+					"version": "3.1.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^2.4.2",
-						"osenv": "^0.1.4",
-						"semver": "^5.1.0",
+						"byline": "^5.0.0",
+						"graceful-fs": "^4.1.15",
+						"node-gyp": "^5.0.2",
+						"resolve-from": "^4.0.0",
+						"slide": "^1.1.6",
+						"uid-number": "0.0.6",
+						"umask": "^1.1.0",
+						"which": "^1.3.1"
+					}
+				},
+				"npm-logical-tree": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"npm-normalize-package-bin": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"npm-package-arg": {
+					"version": "6.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^2.7.1",
+						"osenv": "^0.1.5",
+						"semver": "^5.6.0",
 						"validate-npm-package-name": "^3.0.0"
 					}
 				},
-				"npm-registry-client": {
-					"version": "8.4.0",
+				"npm-packlist": {
+					"version": "1.4.8",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"concat-stream": "^1.5.2",
-						"graceful-fs": "^4.1.6",
-						"normalize-package-data": "~1.0.1 || ^2.0.0",
-						"npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
-						"npmlog": "2 || ^3.1.0 || ^4.0.0",
-						"once": "^1.3.3",
-						"request": "^2.74.0",
-						"retry": "^0.10.0",
-						"semver": "2 >=2.2.1 || 3.x || 4 || 5",
-						"slide": "^1.1.3",
-						"ssri": "^4.1.2"
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1",
+						"npm-normalize-package-bin": "^1.0.1"
+					}
+				},
+				"npm-pick-manifest": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"npm-package-arg": "^6.0.0",
+						"semver": "^5.4.1"
+					}
+				},
+				"npm-profile": {
+					"version": "4.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^1.1.2 || 2",
+						"figgy-pudding": "^3.4.1",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"npm-registry-fetch": {
+					"version": "4.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"JSONStream": "^1.3.4",
+						"bluebird": "^3.5.1",
+						"figgy-pudding": "^3.4.1",
+						"lru-cache": "^5.1.1",
+						"make-fetch-happen": "^5.0.0",
+						"npm-package-arg": "^6.1.0",
+						"safe-buffer": "^5.2.0"
 					},
 					"dependencies": {
-						"concat-stream": {
-							"version": "1.6.0",
+						"safe-buffer": {
+							"version": "5.2.0",
 							"bundled": true,
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"readable-stream": "^2.2.2",
-								"typedarray": "^0.0.6"
-							},
-							"dependencies": {
-								"typedarray": {
-									"version": "0.0.6",
-									"bundled": true,
-									"dev": true
-								}
-							}
+							"dev": true
 						}
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"path-key": "^2.0.0"
 					}
 				},
 				"npm-user-validate": {
@@ -10845,116 +15006,35 @@
 						"console-control-strings": "~1.1.0",
 						"gauge": "~2.7.3",
 						"set-blocking": "~2.0.0"
-					},
-					"dependencies": {
-						"are-we-there-yet": {
-							"version": "1.1.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^2.0.6"
-							},
-							"dependencies": {
-								"delegates": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"console-control-strings": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"gauge": {
-							"version": "2.7.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"aproba": "^1.0.3",
-								"console-control-strings": "^1.0.0",
-								"has-unicode": "^2.0.0",
-								"object-assign": "^4.1.0",
-								"signal-exit": "^3.0.0",
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wide-align": "^1.1.0"
-							},
-							"dependencies": {
-								"object-assign": {
-									"version": "4.1.1",
-									"bundled": true,
-									"dev": true
-								},
-								"signal-exit": {
-									"version": "3.0.2",
-									"bundled": true,
-									"dev": true
-								},
-								"string-width": {
-									"version": "1.0.2",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"code-point-at": "^1.0.0",
-										"is-fullwidth-code-point": "^1.0.0",
-										"strip-ansi": "^3.0.0"
-									},
-									"dependencies": {
-										"code-point-at": {
-											"version": "1.1.0",
-											"bundled": true,
-											"dev": true
-										},
-										"is-fullwidth-code-point": {
-											"version": "1.0.0",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"number-is-nan": "^1.0.0"
-											},
-											"dependencies": {
-												"number-is-nan": {
-													"version": "1.0.1",
-													"bundled": true,
-													"dev": true
-												}
-											}
-										}
-									}
-								},
-								"strip-ansi": {
-									"version": "3.0.1",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^2.0.0"
-									},
-									"dependencies": {
-										"ansi-regex": {
-											"version": "2.1.1",
-											"bundled": true,
-											"dev": true
-										}
-									}
-								},
-								"wide-align": {
-									"version": "1.1.2",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"string-width": "^1.0.2"
-									}
-								}
-							}
-						},
-						"set-blocking": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true
-						}
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"oauth-sign": {
+					"version": "0.9.0",
+					"bundled": true,
+					"dev": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object-keys": {
+					"version": "1.0.12",
+					"bundled": true,
+					"dev": true
+				},
+				"object.getownpropertydescriptors": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.2",
+						"es-abstract": "^1.5.1"
 					}
 				},
 				"once": {
@@ -10966,294 +15046,238 @@
 					}
 				},
 				"opener": {
-					"version": "1.4.3",
+					"version": "1.5.1",
+					"bundled": true,
+					"dev": true
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"os-locale": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"execa": "^1.0.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "6.0.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"nice-try": "^1.0.4",
+								"path-key": "^2.0.1",
+								"semver": "^5.5.0",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						},
+						"execa": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"cross-spawn": "^6.0.0",
+								"get-stream": "^4.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
+							}
+						}
+					}
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
 					"bundled": true,
 					"dev": true
 				},
 				"osenv": {
-					"version": "0.1.4",
+					"version": "0.1.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
 						"os-tmpdir": "^1.0.0"
-					},
-					"dependencies": {
-						"os-homedir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"os-tmpdir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						}
 					}
 				},
-				"pacote": {
-					"version": "2.7.38",
+				"p-defer": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-is-promise": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-limit": {
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.0",
-						"cacache": "^9.2.9",
-						"glob": "^7.1.2",
-						"lru-cache": "^4.1.1",
-						"make-fetch-happen": "^2.4.13",
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"package-json": {
+					"version": "4.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"got": "^6.7.1",
+						"registry-auth-token": "^3.0.1",
+						"registry-url": "^3.0.3",
+						"semver": "^5.1.0"
+					}
+				},
+				"pacote": {
+					"version": "9.5.12",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"bluebird": "^3.5.3",
+						"cacache": "^12.0.2",
+						"chownr": "^1.1.2",
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.1.0",
+						"glob": "^7.1.3",
+						"infer-owner": "^1.0.4",
+						"lru-cache": "^5.1.1",
+						"make-fetch-happen": "^5.0.0",
 						"minimatch": "^3.0.4",
-						"mississippi": "^1.2.0",
+						"minipass": "^2.3.5",
+						"mississippi": "^3.0.0",
+						"mkdirp": "^0.5.1",
 						"normalize-package-data": "^2.4.0",
-						"npm-package-arg": "^5.1.2",
-						"npm-pick-manifest": "^1.0.4",
-						"osenv": "^0.1.4",
+						"npm-normalize-package-bin": "^1.0.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-packlist": "^1.1.12",
+						"npm-pick-manifest": "^3.0.0",
+						"npm-registry-fetch": "^4.0.0",
+						"osenv": "^0.1.5",
 						"promise-inflight": "^1.0.1",
 						"promise-retry": "^1.1.1",
-						"protoduck": "^4.0.0",
-						"safe-buffer": "^5.1.1",
-						"semver": "^5.3.0",
-						"ssri": "^4.1.6",
-						"tar-fs": "^1.15.3",
-						"tar-stream": "^1.5.4",
-						"unique-filename": "^1.1.0",
-						"which": "^1.2.12"
+						"protoduck": "^5.0.1",
+						"rimraf": "^2.6.2",
+						"safe-buffer": "^5.1.2",
+						"semver": "^5.6.0",
+						"ssri": "^6.0.1",
+						"tar": "^4.4.10",
+						"unique-filename": "^1.1.1",
+						"which": "^1.3.1"
 					},
 					"dependencies": {
-						"make-fetch-happen": {
-							"version": "2.4.13",
+						"minipass": {
+							"version": "2.9.0",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"agentkeepalive": "^3.3.0",
-								"cacache": "^9.2.9",
-								"http-cache-semantics": "^3.7.3",
-								"http-proxy-agent": "^2.0.0",
-								"https-proxy-agent": "^2.0.0",
-								"lru-cache": "^4.1.1",
-								"mississippi": "^1.2.0",
-								"node-fetch-npm": "^2.0.1",
-								"promise-retry": "^1.1.1",
-								"socks-proxy-agent": "^3.0.0",
-								"ssri": "^4.1.6"
-							},
-							"dependencies": {
-								"agentkeepalive": {
-									"version": "3.3.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"humanize-ms": "^1.2.1"
-									},
-									"dependencies": {
-										"humanize-ms": {
-											"version": "1.2.1",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"ms": "^2.0.0"
-											},
-											"dependencies": {
-												"ms": {
-													"version": "2.0.0",
-													"bundled": true,
-													"dev": true
-												}
-											}
-										}
-									}
-								},
-								"http-cache-semantics": {
-									"version": "3.7.3",
-									"bundled": true,
-									"dev": true
-								},
-								"node-fetch-npm": {
-									"version": "2.0.1",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"encoding": "^0.1.11",
-										"json-parse-helpfulerror": "^1.0.3",
-										"safe-buffer": "^5.0.1"
-									},
-									"dependencies": {
-										"encoding": {
-											"version": "0.1.12",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"iconv-lite": "~0.4.13"
-											},
-											"dependencies": {
-												"iconv-lite": {
-													"version": "0.4.18",
-													"bundled": true,
-													"dev": true
-												}
-											}
-										},
-										"json-parse-helpfulerror": {
-											"version": "1.0.3",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"jju": "^1.1.0"
-											},
-											"dependencies": {
-												"jju": {
-													"version": "1.3.0",
-													"bundled": true,
-													"dev": true
-												}
-											}
-										}
-									}
-								},
-								"socks-proxy-agent": {
-									"version": "3.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"agent-base": "^4.0.1",
-										"socks": "^1.1.10"
-									},
-									"dependencies": {
-										"agent-base": {
-											"version": "4.1.0",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"es6-promisify": "^5.0.0"
-											},
-											"dependencies": {
-												"es6-promisify": {
-													"version": "5.0.0",
-													"bundled": true,
-													"dev": true,
-													"requires": {
-														"es6-promise": "^4.0.3"
-													},
-													"dependencies": {
-														"es6-promise": {
-															"version": "4.1.1",
-															"bundled": true,
-															"dev": true
-														}
-													}
-												}
-											}
-										},
-										"socks": {
-											"version": "1.1.10",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"ip": "^1.1.4",
-												"smart-buffer": "^1.0.13"
-											},
-											"dependencies": {
-												"ip": {
-													"version": "1.1.5",
-													"bundled": true,
-													"dev": true
-												},
-												"smart-buffer": {
-													"version": "1.1.15",
-													"bundled": true,
-													"dev": true
-												}
-											}
-										}
-									}
-								}
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
 							}
-						},
-						"minimatch": {
-							"version": "3.0.4",
+						}
+					}
+				},
+				"parallel-transform": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cyclist": "~0.2.2",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.1.5"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"brace-expansion": "^1.1.7"
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
 							}
 						},
-						"npm-pick-manifest": {
-							"version": "1.0.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"npm-package-arg": "^5.1.2",
-								"semver": "^5.3.0"
-							}
-						},
-						"promise-retry": {
+						"string_decoder": {
 							"version": "1.1.1",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"err-code": "^1.0.0",
-								"retry": "^0.10.0"
-							},
-							"dependencies": {
-								"err-code": {
-									"version": "1.1.2",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"protoduck": {
-							"version": "4.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"genfun": "^4.0.1"
-							},
-							"dependencies": {
-								"genfun": {
-									"version": "4.0.1",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"tar-stream": {
-							"version": "1.5.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"bl": "^1.0.0",
-								"end-of-stream": "^1.0.0",
-								"readable-stream": "^2.0.0",
-								"xtend": "^4.0.0"
-							},
-							"dependencies": {
-								"bl": {
-									"version": "1.2.1",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"readable-stream": "^2.0.5"
-									}
-								},
-								"end-of-stream": {
-									"version": "1.4.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"once": "^1.4.0"
-									}
-								},
-								"xtend": {
-									"version": "4.0.1",
-									"bundled": true,
-									"dev": true
-								}
+								"safe-buffer": "~5.1.0"
 							}
 						}
 					}
 				},
+				"path-exists": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
 				"path-is-inside": {
 					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true
+				},
+				"performance-now": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"pify": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"prepend-http": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -11262,11 +15286,135 @@
 					"bundled": true,
 					"dev": true
 				},
+				"promise-retry": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"err-code": "^1.0.0",
+						"retry": "^0.10.0"
+					},
+					"dependencies": {
+						"retry": {
+							"version": "0.10.1",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"promzard": {
+					"version": "0.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"read": "1"
+					}
+				},
+				"proto-list": {
+					"version": "1.2.4",
+					"bundled": true,
+					"dev": true
+				},
+				"protoduck": {
+					"version": "5.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"genfun": "^5.0.0"
+					}
+				},
+				"prr": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"psl": {
+					"version": "1.1.29",
+					"bundled": true,
+					"dev": true
+				},
+				"pump": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"pumpify": {
+					"version": "1.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"duplexify": "^3.6.0",
+						"inherits": "^2.0.3",
+						"pump": "^2.0.0"
+					},
+					"dependencies": {
+						"pump": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"end-of-stream": "^1.1.0",
+								"once": "^1.3.1"
+							}
+						}
+					}
+				},
 				"punycode": {
 					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"bundled": true,
 					"dev": true
+				},
+				"qrcode-terminal": {
+					"version": "0.12.0",
+					"bundled": true,
+					"dev": true
+				},
+				"qs": {
+					"version": "6.5.2",
+					"bundled": true,
+					"dev": true
+				},
+				"query-string": {
+					"version": "6.8.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"decode-uri-component": "^0.2.0",
+						"split-on-first": "^1.0.0",
+						"strict-uri-encode": "^2.0.0"
+					}
+				},
+				"qw": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"rc": {
+					"version": "1.2.8",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"deep-extend": "^0.6.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.5",
+							"bundled": true,
+							"dev": true
+						}
+					}
 				},
 				"read": {
 					"version": "1.0.7",
@@ -11274,17 +15422,10 @@
 					"dev": true,
 					"requires": {
 						"mute-stream": "~0.0.4"
-					},
-					"dependencies": {
-						"mute-stream": {
-							"version": "0.0.7",
-							"bundled": true,
-							"dev": true
-						}
 					}
 				},
 				"read-cmd-shim": {
-					"version": "1.0.1",
+					"version": "1.0.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -11303,101 +15444,42 @@
 						"semver": "2 || 3 || 4 || 5",
 						"slide": "~1.1.3",
 						"util-extend": "^1.0.1"
-					},
-					"dependencies": {
-						"util-extend": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true
-						}
 					}
 				},
 				"read-package-json": {
-					"version": "2.0.9",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
 						"graceful-fs": "^4.1.2",
-						"json-parse-helpfulerror": "^1.0.2",
-						"normalize-package-data": "^2.0.0"
-					},
-					"dependencies": {
-						"json-parse-helpfulerror": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"jju": "^1.1.0"
-							},
-							"dependencies": {
-								"jju": {
-									"version": "1.3.0",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						}
+						"json-parse-better-errors": "^1.0.1",
+						"normalize-package-data": "^2.0.0",
+						"npm-normalize-package-bin": "^1.0.0"
 					}
 				},
 				"read-package-tree": {
-					"version": "5.1.6",
+					"version": "5.3.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debuglog": "^1.0.1",
-						"dezalgo": "^1.0.0",
-						"once": "^1.3.0",
 						"read-package-json": "^2.0.0",
-						"readdir-scoped-modules": "^1.0.0"
+						"readdir-scoped-modules": "^1.0.0",
+						"util-promisify": "^2.1.0"
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.2",
+					"version": "3.6.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~1.0.6",
-						"safe-buffer": "~5.1.0",
-						"string_decoder": "~1.0.0",
-						"util-deprecate": "~1.0.1"
-					},
-					"dependencies": {
-						"core-util-is": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"isarray": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"process-nextick-args": {
-							"version": "1.0.7",
-							"bundled": true,
-							"dev": true
-						},
-						"string_decoder": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						},
-						"util-deprecate": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						}
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				},
 				"readdir-scoped-modules": {
-					"version": "1.0.2",
+					"version": "1.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -11407,325 +15489,184 @@
 						"once": "^1.3.0"
 					}
 				},
-				"request": {
-					"version": "2.81.0",
+				"registry-auth-token": {
+					"version": "3.4.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
+						"rc": "^1.1.6",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"registry-url": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"rc": "^1.0.1"
+					}
+				},
+				"request": {
+					"version": "2.88.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.8.0",
 						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
+						"combined-stream": "~1.0.6",
+						"extend": "~3.0.2",
 						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
+						"form-data": "~2.3.2",
+						"har-validator": "~5.1.0",
+						"http-signature": "~1.2.0",
 						"is-typedarray": "~1.0.0",
 						"isstream": "~0.1.2",
 						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
-						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
+						"mime-types": "~2.1.19",
+						"oauth-sign": "~0.9.0",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.2",
+						"safe-buffer": "^5.1.2",
+						"tough-cookie": "~2.4.3",
 						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.0.0"
-					},
-					"dependencies": {
-						"aws-sign2": {
-							"version": "0.6.0",
-							"bundled": true,
-							"dev": true
-						},
-						"aws4": {
-							"version": "1.6.0",
-							"bundled": true,
-							"dev": true
-						},
-						"caseless": {
-							"version": "0.12.0",
-							"bundled": true,
-							"dev": true
-						},
-						"combined-stream": {
-							"version": "1.0.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"delayed-stream": "~1.0.0"
-							},
-							"dependencies": {
-								"delayed-stream": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"extend": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"forever-agent": {
-							"version": "0.6.1",
-							"bundled": true,
-							"dev": true
-						},
-						"form-data": {
-							"version": "2.1.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"asynckit": "^0.4.0",
-								"combined-stream": "^1.0.5",
-								"mime-types": "^2.1.12"
-							},
-							"dependencies": {
-								"asynckit": {
-									"version": "0.4.0",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"har-validator": {
-							"version": "4.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ajv": "^4.9.1",
-								"har-schema": "^1.0.5"
-							},
-							"dependencies": {
-								"ajv": {
-									"version": "4.11.8",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"co": "^4.6.0",
-										"json-stable-stringify": "^1.0.1"
-									},
-									"dependencies": {
-										"co": {
-											"version": "4.6.0",
-											"bundled": true,
-											"dev": true
-										},
-										"json-stable-stringify": {
-											"version": "1.0.1",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"jsonify": "~0.0.0"
-											},
-											"dependencies": {
-												"jsonify": {
-													"version": "0.0.0",
-													"bundled": true,
-													"dev": true
-												}
-											}
-										}
-									}
-								},
-								"har-schema": {
-									"version": "1.0.5",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"hawk": {
-							"version": "3.1.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"boom": "2.x.x",
-								"cryptiles": "2.x.x",
-								"hoek": "2.x.x",
-								"sntp": "1.x.x"
-							},
-							"dependencies": {
-								"boom": {
-									"version": "2.10.1",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"hoek": "2.x.x"
-									}
-								},
-								"cryptiles": {
-									"version": "2.0.5",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"boom": "2.x.x"
-									}
-								},
-								"hoek": {
-									"version": "2.16.3",
-									"bundled": true,
-									"dev": true
-								},
-								"sntp": {
-									"version": "1.0.9",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"hoek": "2.x.x"
-									}
-								}
-							}
-						},
-						"http-signature": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"assert-plus": "^0.2.0",
-								"jsprim": "^1.2.2",
-								"sshpk": "^1.7.0"
-							},
-							"dependencies": {
-								"assert-plus": {
-									"version": "0.2.0",
-									"bundled": true,
-									"dev": true
-								},
-								"jsprim": {
-									"version": "1.4.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"assert-plus": "1.0.0",
-										"extsprintf": "1.0.2",
-										"json-schema": "0.2.3",
-										"verror": "1.3.6"
-									},
-									"dependencies": {
-										"assert-plus": {
-											"version": "1.0.0",
-											"bundled": true,
-											"dev": true
-										},
-										"extsprintf": {
-											"version": "1.0.2",
-											"bundled": true,
-											"dev": true
-										},
-										"json-schema": {
-											"version": "0.2.3",
-											"bundled": true,
-											"dev": true
-										},
-										"verror": {
-											"version": "1.3.6",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"extsprintf": "1.0.2"
-											}
-										}
-									}
-								}
-							}
-						},
-						"is-typedarray": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"isstream": {
-							"version": "0.1.2",
-							"bundled": true,
-							"dev": true
-						},
-						"json-stringify-safe": {
-							"version": "5.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"mime-types": {
-							"version": "2.1.15",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"mime-db": "~1.27.0"
-							},
-							"dependencies": {
-								"mime-db": {
-									"version": "1.27.0",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"oauth-sign": {
-							"version": "0.8.2",
-							"bundled": true,
-							"dev": true
-						},
-						"performance-now": {
-							"version": "0.2.0",
-							"bundled": true,
-							"dev": true
-						},
-						"qs": {
-							"version": "6.4.0",
-							"bundled": true,
-							"dev": true
-						},
-						"tunnel-agent": {
-							"version": "0.6.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"safe-buffer": "^5.0.1"
-							}
-						}
+						"uuid": "^3.3.2"
 					}
 				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true
+				},
 				"retry": {
-					"version": "0.10.1",
+					"version": "0.12.0",
 					"bundled": true,
 					"dev": true
 				},
 				"rimraf": {
-					"version": "2.6.1",
+					"version": "2.7.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
+					}
+				},
+				"run-queue": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^1.1.1"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
 					"bundled": true,
 					"dev": true
 				},
 				"semver": {
-					"version": "5.3.0",
+					"version": "5.7.1",
+					"bundled": true,
+					"dev": true
+				},
+				"semver-diff": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"semver": "^5.0.3"
+					}
+				},
+				"set-blocking": {
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"sha": {
-					"version": "2.0.1",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"readable-stream": "^2.0.2"
+						"graceful-fs": "^4.1.2"
 					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
 					"bundled": true,
 					"dev": true
+				},
+				"smart-buffer": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"socks": {
+					"version": "2.3.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ip": "1.1.5",
+						"smart-buffer": "^4.1.0"
+					}
+				},
+				"socks-proxy-agent": {
+					"version": "4.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"agent-base": "~4.2.1",
+						"socks": "~2.3.2"
+					},
+					"dependencies": {
+						"agent-base": {
+							"version": "4.2.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"es6-promisify": "^5.0.0"
+							}
+						}
+					}
 				},
 				"sorted-object": {
 					"version": "2.0.1",
@@ -11748,77 +15689,246 @@
 							"requires": {
 								"inherits": "~2.0.1",
 								"readable-stream": "~1.1.10"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "1.1.14",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.1",
-										"isarray": "0.0.1",
-										"string_decoder": "~0.10.x"
-									},
-									"dependencies": {
-										"core-util-is": {
-											"version": "1.0.2",
-											"bundled": true,
-											"dev": true
-										},
-										"isarray": {
-											"version": "0.0.1",
-											"bundled": true,
-											"dev": true
-										},
-										"string_decoder": {
-											"version": "0.10.31",
-											"bundled": true,
-											"dev": true
-										}
-									}
-								}
 							}
 						},
-						"stream-iterate": {
-							"version": "1.2.0",
+						"isarray": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "1.1.14",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"readable-stream": "^2.1.5",
-								"stream-shift": "^1.0.0"
-							},
-							"dependencies": {
-								"stream-shift": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true
-								}
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.1",
+								"isarray": "0.0.1",
+								"string_decoder": "~0.10.x"
+							}
+						},
+						"string_decoder": {
+							"version": "0.10.31",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"split-on-first": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"sshpk": {
+					"version": "1.14.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"asn1": "~0.2.3",
+						"assert-plus": "^1.0.0",
+						"bcrypt-pbkdf": "^1.0.0",
+						"dashdash": "^1.12.0",
+						"ecc-jsbn": "~0.1.1",
+						"getpass": "^0.1.1",
+						"jsbn": "~0.1.0",
+						"safer-buffer": "^2.0.2",
+						"tweetnacl": "~0.14.0"
+					}
+				},
+				"ssri": {
+					"version": "6.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1"
+					}
+				},
+				"stream-each": {
+					"version": "1.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"stream-shift": "^1.0.0"
+					}
+				},
+				"stream-iterate": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"readable-stream": "^2.1.5",
+						"stream-shift": "^1.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
 							}
 						}
 					}
 				},
-				"ssri": {
-					"version": "4.1.6",
+				"stream-shift": {
+					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safe-buffer": "^5.1.0"
-					}
+					"dev": true
 				},
-				"strip-ansi": {
-					"version": "4.0.0",
+				"strict-uri-encode": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
 							"bundled": true,
 							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
 						}
+					}
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					},
+					"dependencies": {
+						"safe-buffer": {
+							"version": "5.2.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"stringify-package": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"tar": {
+					"version": "4.4.13",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.8.6",
+						"minizlib": "^1.2.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.3"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						}
+					}
+				},
+				"term-size": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"execa": "^0.7.0"
 					}
 				},
 				"text-table": {
@@ -11826,14 +15936,81 @@
 					"bundled": true,
 					"dev": true
 				},
-				"tough-cookie": {
-					"version": "2.3.4",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+				"through": {
+					"version": "2.3.8",
+					"bundled": true,
+					"dev": true
+				},
+				"through2": {
+					"version": "2.0.3",
+					"bundled": true,
 					"dev": true,
 					"requires": {
+						"readable-stream": "^2.1.5",
+						"xtend": "~4.0.1"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"timed-out": {
+					"version": "4.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"tiny-relative-date": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.24",
 						"punycode": "^1.4.1"
 					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"typedarray": {
+					"version": "0.0.6",
+					"bundled": true,
+					"dev": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
@@ -11846,21 +16023,27 @@
 					"dev": true
 				},
 				"unique-filename": {
-					"version": "1.1.0",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"unique-slug": "^2.0.0"
-					},
-					"dependencies": {
-						"unique-slug": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"imurmurhash": "^0.1.4"
-							}
-						}
+					}
+				},
+				"unique-slug": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4"
+					}
+				},
+				"unique-string": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"crypto-random-string": "^1.0.0"
 					}
 				},
 				"unpipe": {
@@ -11868,566 +16051,66 @@
 					"bundled": true,
 					"dev": true
 				},
+				"unzip-response": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
 				"update-notifier": {
-					"version": "2.2.0",
+					"version": "2.5.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"boxen": "^1.0.0",
-						"chalk": "^1.0.0",
+						"boxen": "^1.2.1",
+						"chalk": "^2.0.1",
 						"configstore": "^3.0.0",
 						"import-lazy": "^2.1.0",
+						"is-ci": "^1.0.10",
+						"is-installed-globally": "^0.1.0",
 						"is-npm": "^1.0.0",
 						"latest-version": "^3.0.0",
 						"semver-diff": "^2.0.0",
 						"xdg-basedir": "^3.0.0"
-					},
-					"dependencies": {
-						"boxen": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-align": "^2.0.0",
-								"camelcase": "^4.0.0",
-								"chalk": "^1.1.1",
-								"cli-boxes": "^1.0.0",
-								"string-width": "^2.0.0",
-								"term-size": "^0.1.0",
-								"widest-line": "^1.0.0"
-							},
-							"dependencies": {
-								"ansi-align": {
-									"version": "2.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"string-width": "^2.0.0"
-									}
-								},
-								"camelcase": {
-									"version": "4.1.0",
-									"bundled": true,
-									"dev": true
-								},
-								"cli-boxes": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true
-								},
-								"string-width": {
-									"version": "2.1.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"is-fullwidth-code-point": "^2.0.0",
-										"strip-ansi": "^4.0.0"
-									},
-									"dependencies": {
-										"is-fullwidth-code-point": {
-											"version": "2.0.0",
-											"bundled": true,
-											"dev": true
-										},
-										"strip-ansi": {
-											"version": "4.0.0",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"ansi-regex": "^3.0.0"
-											}
-										}
-									}
-								},
-								"term-size": {
-									"version": "0.1.1",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"execa": "^0.4.0"
-									},
-									"dependencies": {
-										"execa": {
-											"version": "0.4.0",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"cross-spawn-async": "^2.1.1",
-												"is-stream": "^1.1.0",
-												"npm-run-path": "^1.0.0",
-												"object-assign": "^4.0.1",
-												"path-key": "^1.0.0",
-												"strip-eof": "^1.0.0"
-											},
-											"dependencies": {
-												"cross-spawn-async": {
-													"version": "2.2.5",
-													"bundled": true,
-													"dev": true,
-													"requires": {
-														"lru-cache": "^4.0.0",
-														"which": "^1.2.8"
-													}
-												},
-												"is-stream": {
-													"version": "1.1.0",
-													"bundled": true,
-													"dev": true
-												},
-												"npm-run-path": {
-													"version": "1.0.0",
-													"bundled": true,
-													"dev": true,
-													"requires": {
-														"path-key": "^1.0.0"
-													}
-												},
-												"object-assign": {
-													"version": "4.1.1",
-													"bundled": true,
-													"dev": true
-												},
-												"path-key": {
-													"version": "1.0.0",
-													"bundled": true,
-													"dev": true
-												},
-												"strip-eof": {
-													"version": "1.0.0",
-													"bundled": true,
-													"dev": true
-												}
-											}
-										}
-									}
-								},
-								"widest-line": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"string-width": "^1.0.1"
-									},
-									"dependencies": {
-										"string-width": {
-											"version": "1.0.2",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"code-point-at": "^1.0.0",
-												"is-fullwidth-code-point": "^1.0.0",
-												"strip-ansi": "^3.0.0"
-											},
-											"dependencies": {
-												"code-point-at": {
-													"version": "1.1.0",
-													"bundled": true,
-													"dev": true
-												},
-												"is-fullwidth-code-point": {
-													"version": "1.0.0",
-													"bundled": true,
-													"dev": true,
-													"requires": {
-														"number-is-nan": "^1.0.0"
-													},
-													"dependencies": {
-														"number-is-nan": {
-															"version": "1.0.1",
-															"bundled": true,
-															"dev": true
-														}
-													}
-												},
-												"strip-ansi": {
-													"version": "3.0.1",
-													"bundled": true,
-													"dev": true,
-													"requires": {
-														"ansi-regex": "^2.0.0"
-													},
-													"dependencies": {
-														"ansi-regex": {
-															"version": "2.1.1",
-															"bundled": true,
-															"dev": true
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						},
-						"chalk": {
-							"version": "1.1.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^2.2.1",
-								"escape-string-regexp": "^1.0.2",
-								"has-ansi": "^2.0.0",
-								"strip-ansi": "^3.0.0",
-								"supports-color": "^2.0.0"
-							},
-							"dependencies": {
-								"ansi-styles": {
-									"version": "2.2.1",
-									"bundled": true,
-									"dev": true
-								},
-								"escape-string-regexp": {
-									"version": "1.0.5",
-									"bundled": true,
-									"dev": true
-								},
-								"has-ansi": {
-									"version": "2.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^2.0.0"
-									},
-									"dependencies": {
-										"ansi-regex": {
-											"version": "2.1.1",
-											"bundled": true,
-											"dev": true
-										}
-									}
-								},
-								"strip-ansi": {
-									"version": "3.0.1",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^2.0.0"
-									},
-									"dependencies": {
-										"ansi-regex": {
-											"version": "2.1.1",
-											"bundled": true,
-											"dev": true
-										}
-									}
-								},
-								"supports-color": {
-									"version": "2.0.0",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"configstore": {
-							"version": "3.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"dot-prop": "^4.1.0",
-								"graceful-fs": "^4.1.2",
-								"make-dir": "^1.0.0",
-								"unique-string": "^1.0.0",
-								"write-file-atomic": "^2.0.0",
-								"xdg-basedir": "^3.0.0"
-							},
-							"dependencies": {
-								"dot-prop": {
-									"version": "4.1.1",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"is-obj": "^1.0.0"
-									},
-									"dependencies": {
-										"is-obj": {
-											"version": "1.0.1",
-											"bundled": true,
-											"dev": true
-										}
-									}
-								},
-								"make-dir": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"pify": "^2.3.0"
-									},
-									"dependencies": {
-										"pify": {
-											"version": "2.3.0",
-											"bundled": true,
-											"dev": true
-										}
-									}
-								},
-								"unique-string": {
-									"version": "1.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"crypto-random-string": "^1.0.0"
-									},
-									"dependencies": {
-										"crypto-random-string": {
-											"version": "1.0.0",
-											"bundled": true,
-											"dev": true
-										}
-									}
-								}
-							}
-						},
-						"import-lazy": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"is-npm": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"latest-version": {
-							"version": "3.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"package-json": "^4.0.0"
-							},
-							"dependencies": {
-								"package-json": {
-									"version": "4.0.1",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"got": "^6.7.1",
-										"registry-auth-token": "^3.0.1",
-										"registry-url": "^3.0.3",
-										"semver": "^5.1.0"
-									},
-									"dependencies": {
-										"got": {
-											"version": "6.7.1",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"create-error-class": "^3.0.0",
-												"duplexer3": "^0.1.4",
-												"get-stream": "^3.0.0",
-												"is-redirect": "^1.0.0",
-												"is-retry-allowed": "^1.0.0",
-												"is-stream": "^1.0.0",
-												"lowercase-keys": "^1.0.0",
-												"safe-buffer": "^5.0.1",
-												"timed-out": "^4.0.0",
-												"unzip-response": "^2.0.1",
-												"url-parse-lax": "^1.0.0"
-											},
-											"dependencies": {
-												"create-error-class": {
-													"version": "3.0.2",
-													"bundled": true,
-													"dev": true,
-													"requires": {
-														"capture-stack-trace": "^1.0.0"
-													},
-													"dependencies": {
-														"capture-stack-trace": {
-															"version": "1.0.0",
-															"bundled": true,
-															"dev": true
-														}
-													}
-												},
-												"duplexer3": {
-													"version": "0.1.4",
-													"bundled": true,
-													"dev": true
-												},
-												"get-stream": {
-													"version": "3.0.0",
-													"bundled": true,
-													"dev": true
-												},
-												"is-redirect": {
-													"version": "1.0.0",
-													"bundled": true,
-													"dev": true
-												},
-												"is-retry-allowed": {
-													"version": "1.1.0",
-													"bundled": true,
-													"dev": true
-												},
-												"is-stream": {
-													"version": "1.1.0",
-													"bundled": true,
-													"dev": true
-												},
-												"lowercase-keys": {
-													"version": "1.0.0",
-													"bundled": true,
-													"dev": true
-												},
-												"timed-out": {
-													"version": "4.0.1",
-													"bundled": true,
-													"dev": true
-												},
-												"unzip-response": {
-													"version": "2.0.1",
-													"bundled": true,
-													"dev": true
-												},
-												"url-parse-lax": {
-													"version": "1.0.0",
-													"bundled": true,
-													"dev": true,
-													"requires": {
-														"prepend-http": "^1.0.1"
-													},
-													"dependencies": {
-														"prepend-http": {
-															"version": "1.0.4",
-															"bundled": true,
-															"dev": true
-														}
-													}
-												}
-											}
-										},
-										"registry-auth-token": {
-											"version": "3.3.1",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"rc": "^1.1.6",
-												"safe-buffer": "^5.0.1"
-											},
-											"dependencies": {
-												"rc": {
-													"version": "1.2.1",
-													"bundled": true,
-													"dev": true,
-													"requires": {
-														"deep-extend": "~0.4.0",
-														"ini": "~1.3.0",
-														"minimist": "^1.2.0",
-														"strip-json-comments": "~2.0.1"
-													},
-													"dependencies": {
-														"deep-extend": {
-															"version": "0.4.2",
-															"bundled": true,
-															"dev": true
-														},
-														"minimist": {
-															"version": "1.2.0",
-															"bundled": true,
-															"dev": true
-														},
-														"strip-json-comments": {
-															"version": "2.0.1",
-															"bundled": true,
-															"dev": true
-														}
-													}
-												}
-											}
-										},
-										"registry-url": {
-											"version": "3.1.0",
-											"bundled": true,
-											"dev": true,
-											"requires": {
-												"rc": "^1.0.1"
-											},
-											"dependencies": {
-												"rc": {
-													"version": "1.2.1",
-													"bundled": true,
-													"dev": true,
-													"requires": {
-														"deep-extend": "~0.4.0",
-														"ini": "~1.3.0",
-														"minimist": "^1.2.0",
-														"strip-json-comments": "~2.0.1"
-													},
-													"dependencies": {
-														"deep-extend": {
-															"version": "0.4.2",
-															"bundled": true,
-															"dev": true
-														},
-														"minimist": {
-															"version": "1.2.0",
-															"bundled": true,
-															"dev": true
-														},
-														"strip-json-comments": {
-															"version": "2.0.1",
-															"bundled": true,
-															"dev": true
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						},
-						"semver-diff": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"semver": "^5.0.3"
-							}
-						},
-						"xdg-basedir": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
-						}
+					}
+				},
+				"url-parse-lax": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"prepend-http": "^1.0.1"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"util-extend": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"util-promisify": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"object.getownpropertydescriptors": "^2.0.3"
 					}
 				},
 				"uuid": {
-					"version": "3.1.0",
+					"version": "3.3.3",
 					"bundled": true,
 					"dev": true
 				},
 				"validate-npm-package-license": {
-					"version": "3.0.1",
+					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-correct": "~1.0.0",
-						"spdx-expression-parse": "~1.0.0"
-					},
-					"dependencies": {
-						"spdx-correct": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"spdx-license-ids": "^1.0.2"
-							},
-							"dependencies": {
-								"spdx-license-ids": {
-									"version": "1.2.2",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"spdx-expression-parse": {
-							"version": "1.0.4",
-							"bundled": true,
-							"dev": true
-						}
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"validate-npm-package-name": {
@@ -12436,58 +16119,93 @@
 					"dev": true,
 					"requires": {
 						"builtins": "^1.0.3"
-					},
-					"dependencies": {
-						"builtins": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true
-						}
 					}
 				},
-				"which": {
-					"version": "1.2.14",
+				"verror": {
+					"version": "1.10.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isexe": "^2.0.0"
-					},
-					"dependencies": {
-						"isexe": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true
-						}
+						"assert-plus": "^1.0.0",
+						"core-util-is": "1.0.2",
+						"extsprintf": "^1.2.0"
 					}
 				},
-				"worker-farm": {
+				"wcwidth": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"defaults": "^1.0.3"
+					}
+				},
+				"which": {
 					"version": "1.3.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"errno": ">=0.1.1 <0.2.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.2"
 					},
 					"dependencies": {
-						"errno": {
-							"version": "0.1.4",
+						"string-width": {
+							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"prr": "~0.0.0"
-							},
-							"dependencies": {
-								"prr": {
-									"version": "0.0.0",
-									"bundled": true,
-									"dev": true
-								}
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
-						},
-						"xtend": {
-							"version": "4.0.1",
+						}
+					}
+				},
+				"widest-line": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "^2.1.1"
+					}
+				},
+				"worker-farm": {
+					"version": "1.7.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"errno": "~0.1.7"
+					}
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
 						}
 					}
 				},
@@ -12497,13 +16215,67 @@
 					"dev": true
 				},
 				"write-file-atomic": {
-					"version": "2.1.0",
+					"version": "2.4.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"xdg-basedir": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"xtend": {
+					"version": "4.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"yargs": {
+					"version": "11.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.1.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
+					},
+					"dependencies": {
+						"y18n": {
+							"version": "3.2.1",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "9.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -14337,6 +18109,17 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
 		},
+		"os-locale": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"dev": true,
+			"requires": {
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			}
+		},
 		"os-name": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -14363,10 +18146,22 @@
 				"os-tmpdir": "^1.0.0"
 			}
 		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
+		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 			"dev": true
 		},
 		"p-limit": {
@@ -14801,12 +18596,6 @@
 			"requires": {
 				"genfun": "^5.0.0"
 			}
-		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
 		},
 		"psl": {
 			"version": "1.1.31",
@@ -15324,9 +19113,9 @@
 			},
 			"dependencies": {
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				}
 			}
@@ -15356,9 +19145,9 @@
 			"dev": true
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -16064,45 +19853,6 @@
 				"inherits": "2"
 			}
 		},
-		"tar-fs": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-			"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-			"dev": true,
-			"requires": {
-				"chownr": "^1.0.1",
-				"mkdirp": "^0.5.1",
-				"pump": "^1.0.0",
-				"tar-stream": "^1.1.2"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
-			}
-		},
-		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-			"dev": true,
-			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
-				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
-			}
-		},
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -16382,12 +20132,6 @@
 			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
 			"dev": true
 		},
-		"to-buffer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-			"dev": true
-		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -16530,20 +20274,19 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.1.tgz",
+			"integrity": "sha512-JUPoL1jHsc9fOjVFHdQIhqEEJsQvfKDjlubcCilu8U26uZ73qOg8VsN8O1jbuei44ZPlwL7kmbAdM4tzaUvqnA==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "~2.17.1",
-				"source-map": "~0.6.1"
+				"commander": "~2.20.3"
 			},
 			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 					"dev": true,
 					"optional": true
 				}
@@ -16562,38 +20305,15 @@
 			"dev": true
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"unique-filename": {
@@ -16801,9 +20521,9 @@
 			},
 			"dependencies": {
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				}
 			}
@@ -17013,12 +20733,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-			"dev": true
-		},
-		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 			"dev": true
 		},
 		"yargs": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "install": "lerna exec --concurrency 1 -- npm ci && lerna link",
+    "bootstrap": "lerna exec --concurrency 1 -- npm i && lerna link",
+    "bootstrap:ci": "lerna exec --concurrency 1 -- npm ci && lerna link",
     "test:lint": "eslint .",
     "test": "lerna run --concurrency 1 test -- -- --config=../../jest.config.js",
     "diff": "lerna diff",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "install": "lerna bootstrap --concurrency=2",
+    "install": "lerna exec --concurrency 1 -- npm ci && lerna link",
     "test:lint": "eslint .",
     "test": "lerna run --concurrency 1 test -- -- --config=../../jest.config.js",
     "diff": "lerna diff",
@@ -26,7 +26,8 @@
     "husky": "^1.3.1",
     "jest": "^23.1.0",
     "lerna": "^3.20.2",
-    "lint-staged": "^8.1.4"
+    "lint-staged": "^8.1.4",
+    "npm": "^6.14.4"
   },
   "husky": {
     "hooks": {

--- a/packages/lambda-powertools-cloudwatchevents-client/package-lock.json
+++ b/packages/lambda-powertools-cloudwatchevents-client/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
+		"@dazn/lambda-powertools-logger": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+			"integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+			"requires": {
+				"@dazn/lambda-powertools-correlation-ids": "1.23.0"
+			}
+		},
 		"aws-sdk": {
 			"version": "2.596.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.596.0.tgz",

--- a/packages/lambda-powertools-dynamodb-client/package-lock.json
+++ b/packages/lambda-powertools-dynamodb-client/package-lock.json
@@ -4,6 +4,11 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
 		"aws-sdk": {
 			"version": "2.538.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.538.0.tgz",

--- a/packages/lambda-powertools-eventbridge-client/package-lock.json
+++ b/packages/lambda-powertools-eventbridge-client/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
+		"@dazn/lambda-powertools-logger": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+			"integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+			"requires": {
+				"@dazn/lambda-powertools-correlation-ids": "1.23.0"
+			}
+		},
 		"aws-sdk": {
 			"version": "2.596.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.596.0.tgz",

--- a/packages/lambda-powertools-firehose-client/package-lock.json
+++ b/packages/lambda-powertools-firehose-client/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
+		"@dazn/lambda-powertools-logger": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+			"integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+			"requires": {
+				"@dazn/lambda-powertools-correlation-ids": "1.23.0"
+			}
+		},
 		"aws-sdk": {
 			"version": "2.540.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",

--- a/packages/lambda-powertools-http-client/package-lock.json
+++ b/packages/lambda-powertools-http-client/package-lock.json
@@ -12,6 +12,11 @@
         "datadog-metrics": "0.8.1"
       }
     },
+    "@dazn/lambda-powertools-correlation-ids": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",

--- a/packages/lambda-powertools-kinesis-client/package-lock.json
+++ b/packages/lambda-powertools-kinesis-client/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
+		"@dazn/lambda-powertools-logger": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+			"integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+			"requires": {
+				"@dazn/lambda-powertools-correlation-ids": "1.23.0"
+			}
+		},
 		"aws-sdk": {
 			"version": "2.540.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",

--- a/packages/lambda-powertools-lambda-client/package-lock.json
+++ b/packages/lambda-powertools-lambda-client/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
+		"@dazn/lambda-powertools-logger": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+			"integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+			"requires": {
+				"@dazn/lambda-powertools-correlation-ids": "1.23.0"
+			}
+		},
 		"aws-sdk": {
 			"version": "2.540.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",

--- a/packages/lambda-powertools-logger/package-lock.json
+++ b/packages/lambda-powertools-logger/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dazn/lambda-powertools-correlation-ids": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.8.2.tgz",
-      "integrity": "sha512-zZvahepZI7vC3qvT+z0eVXbt9gJ6vHK0UJcw2IZ5EOhocYfOJhNsaGIv6HdOp8nDGAQkVLH8IY3Ih/wLoBU4Lg=="
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
     }
   }
 }

--- a/packages/lambda-powertools-middleware-correlation-ids/package-lock.json
+++ b/packages/lambda-powertools-middleware-correlation-ids/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@dazn/lambda-powertools-correlation-ids": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+    },
+    "@dazn/lambda-powertools-logger": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+      "integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
+      }
+    },
     "@types/aws-lambda": {
       "version": "8.10.6",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.6.tgz",

--- a/packages/lambda-powertools-middleware-log-timeout/package-lock.json
+++ b/packages/lambda-powertools-middleware-log-timeout/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
+		"@dazn/lambda-powertools-logger": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+			"integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+			"requires": {
+				"@dazn/lambda-powertools-correlation-ids": "1.23.0"
+			}
+		},
 		"@types/aws-lambda": {
 			"version": "8.10.26",
 			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.26.tgz",

--- a/packages/lambda-powertools-middleware-obfuscater/package-lock.json
+++ b/packages/lambda-powertools-middleware-obfuscater/package-lock.json
@@ -32,6 +32,19 @@
         }
       }
     },
+    "@dazn/lambda-powertools-correlation-ids": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+    },
+    "@dazn/lambda-powertools-logger": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+      "integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
+      }
+    },
     "@types/aws-lambda": {
       "version": "8.10.19",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.19.tgz",

--- a/packages/lambda-powertools-middleware-sample-logging/package-lock.json
+++ b/packages/lambda-powertools-middleware-sample-logging/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@dazn/lambda-powertools-correlation-ids": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+    },
+    "@dazn/lambda-powertools-logger": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+      "integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
+      }
+    },
     "@types/aws-lambda": {
       "version": "8.10.6",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.6.tgz",

--- a/packages/lambda-powertools-middleware-stop-infinite-loop/package-lock.json
+++ b/packages/lambda-powertools-middleware-stop-infinite-loop/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
+		"@dazn/lambda-powertools-logger": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+			"integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+			"requires": {
+				"@dazn/lambda-powertools-correlation-ids": "1.23.0"
+			}
+		},
 		"@types/aws-lambda": {
 			"version": "8.10.27",
 			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.27.tgz",

--- a/packages/lambda-powertools-pattern-basic/package-lock.json
+++ b/packages/lambda-powertools-pattern-basic/package-lock.json
@@ -4,6 +4,45 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@dazn/lambda-powertools-correlation-ids": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+    },
+    "@dazn/lambda-powertools-logger": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+      "integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-correlation-ids": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-correlation-ids/-/lambda-powertools-middleware-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-zZ2GEk87BGIlpCr5KLu5ooPCzOM=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-log-timeout": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-log-timeout/-/lambda-powertools-middleware-log-timeout-1.23.0.tgz",
+      "integrity": "sha1-vRmwkbD9cYP/9NpBBf159zwTCzo=",
+      "requires": {
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-sample-logging": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-sample-logging/-/lambda-powertools-middleware-sample-logging-1.23.0.tgz",
+      "integrity": "sha1-przT9S7BOGZF6OvPC0/u8a+telk=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
     "@types/aws-lambda": {
       "version": "8.10.6",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.6.tgz",

--- a/packages/lambda-powertools-pattern-obfuscate/package-lock.json
+++ b/packages/lambda-powertools-pattern-obfuscate/package-lock.json
@@ -24,6 +24,54 @@
         "js-tokens": "3.0.2"
       }
     },
+    "@dazn/lambda-powertools-correlation-ids": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+    },
+    "@dazn/lambda-powertools-logger": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+      "integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-correlation-ids": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-correlation-ids/-/lambda-powertools-middleware-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-zZ2GEk87BGIlpCr5KLu5ooPCzOM=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-log-timeout": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-log-timeout/-/lambda-powertools-middleware-log-timeout-1.23.0.tgz",
+      "integrity": "sha1-vRmwkbD9cYP/9NpBBf159zwTCzo=",
+      "requires": {
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-obfuscater": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-obfuscater/-/lambda-powertools-middleware-obfuscater-1.23.0.tgz",
+      "integrity": "sha1-W3C0WkMRP6Lcv0LIyx7hUVx+kxs=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-sample-logging": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-middleware-sample-logging/-/lambda-powertools-middleware-sample-logging-1.23.0.tgz",
+      "integrity": "sha1-przT9S7BOGZF6OvPC0/u8a+telk=",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "1.23.0",
+        "@dazn/lambda-powertools-logger": "1.23.0"
+      }
+    },
     "@types/aws-lambda": {
       "version": "8.10.6",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.6.tgz",

--- a/packages/lambda-powertools-sns-client/package-lock.json
+++ b/packages/lambda-powertools-sns-client/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@dazn/lambda-powertools-correlation-ids": {
+      "version": "1.23.0",
+      "resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+      "integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+    },
     "aws-sdk": {
       "version": "2.540.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",

--- a/packages/lambda-powertools-sqs-client/package-lock.json
+++ b/packages/lambda-powertools-sqs-client/package-lock.json
@@ -4,6 +4,11 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
 		"aws-sdk": {
 			"version": "2.540.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",

--- a/packages/lambda-powertools-step-functions-client/package-lock.json
+++ b/packages/lambda-powertools-step-functions-client/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dazn/lambda-powertools-correlation-ids": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.23.0.tgz",
+			"integrity": "sha1-C9MqpxQp8i09+mEW6KlALZ0bMvg="
+		},
+		"@dazn/lambda-powertools-logger": {
+			"version": "1.23.0",
+			"resolved": "https://npm.daznplatform.com/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.23.0.tgz",
+			"integrity": "sha1-YRZzIhlwghZxkzPqvgdk8qdctv4=",
+			"requires": {
+				"@dazn/lambda-powertools-correlation-ids": "1.23.0"
+			}
+		},
 		"aws-sdk": {
 			"version": "2.540.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.540.0.tgz",


### PR DESCRIPTION
## What did you implement:

When running `lerna bootstrap` all dependencies should be installed in packages. However, due to a bug listed: https://github.com/lerna/lerna/issues/1457, this doesn't currently happen. Due to this, package-lock files for all packages are not fully representative of all deps and dev deps.

As a workaround, update from using `lerna bootstrap` to performing the commands as 2 commands manually.

This will allow package-lock files to be in sync as well as allowing dependabot automated updates to not fail.

All package-lock files have also been updated as a result.
<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Update the `install` npm script to run `lerna exec npm ci && lerna link`

## How can we verify it:

Run `npm i` and ensure all packages have dependencies install and symlinked with package-lock files also updated with all dependencies.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
