### PR TITLE
ci(circleci): update install script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - run: npm ci
-      - run: npm run bootstrap:ci
+      - run: npm run bootstrap
       - *PERSIST_TO_WORKSPACE
   test-node12:
     docker:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "scripts": {
     "bootstrap": "lerna exec --concurrency 1 -- npm i && lerna link",
-    "bootstrap:ci": "lerna exec --concurrency 1 -- npm ci && lerna link",
     "test:lint": "eslint .",
     "test": "lerna run --concurrency 1 test -- -- --config=../../jest.config.js",
     "diff": "lerna diff",


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Use `npm i` instead of `npm ci` during bootstrapping so that package-lock files can be in sync with previously published powertools packages. This is because, lerna does not update the dependency versions in lock files during `lerna version` and future builds fail as lock files are out of sync when doing `npm ci` on future builds.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Use `npm i` instead of `lerna exec npm ci`.

## How can we verify it:

The build in this PR passes (since master has received a released version bump recently).

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
