### PR TITLE
docs(readme): typo

### DIFF
--- a/packages/lambda-powertools-middleware-correlation-ids/README.md
+++ b/packages/lambda-powertools-middleware-correlation-ids/README.md
@@ -20,7 +20,7 @@ Main features:
 
 * captures anything with prefix `x-correlation-`
 
-* cpatures `User-Agent` from API Gateway events
+* captures `User-Agent` from API Gateway events
 
 * captures or initializes the `debug-log-enabled` decision based on configuration (see below) to ensure invocation follows upstream decision to enable debug logging for a small % of invocations
 


### PR DESCRIPTION
## What did you implement:

Just a really quick fix to a typo as on the below page:

https://github.com/getndazn/dazn-lambda-powertools/tree/master/packages/lambda-powertools-middleware-correlation-ids

## How can we verify it:

Review the readme

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / projects / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
