### PR TITLE
feat: added support for setting debug logging within CorrelationIds

### DIFF
--- a/packages/lambda-powertools-correlation-ids/README.md
+++ b/packages/lambda-powertools-correlation-ids/README.md
@@ -8,6 +8,8 @@ Main features:
 
 * respects convention for correlation IDs - i.e. `x-correlation-`
 
+* Manually enable/disable debug logging (`debug-log-enabled`) to be picked up by other/downstream middleware
+
 * allows you to store more than one correlation IDs, which allows you to *correlate* logs on multiple dimensions (e.g. by `x-correlation-user-id`, or `x-correlation-order-id`, etc.)
 
 ## Getting Started
@@ -23,17 +25,24 @@ const CorrelationIds = require('@dazn/lambda-powertools-correlation-ids')
 CorrelationIds.set('id', '12345678') // records id as x-correlation-id
 CorrelationIds.set('x-correlation-username', 'theburningmonk') // records as x-correlation-username
 
+// Manully enable debug logging (debug-log-enabled)
+CorrelationIds.debugLoggingEnabled = true
+
 const myCorrelationIds = CorrelationIds.get()
 // {
 //   'x-correlation-id': '12345678',
-//   'x-correlation-username': 'theburningmonk'
+//   'x-correlation-username': 'theburningmonk',
+//   'debug-log-enabled': 'true'
 // }
 
 CorrelationIds.clearAll() // removes all recorded correlation IDs
 CorrelationIds.replaceAllWith({  // bypasses the 'x-correlation-' convention
-  'DEBUG-LOG-ENABLED': 'true',
+  'debug-log-enabled': 'true',
   'User-Agent': 'jest test'
 })
+
+// Disable debug logging
+CorrelationIds.debugLoggingEnabled = false
 ```
 
 In practice, you're likely to only need `set` when you want to record correlation IDs from your function.

--- a/packages/lambda-powertools-correlation-ids/__tests__/index.js
+++ b/packages/lambda-powertools-correlation-ids/__tests__/index.js
@@ -43,6 +43,18 @@ const suite = (correlationIds) => () => {
     })
   })
 
+  describe('get/set debug logging', () => {
+    it('GETS and SETS state of debug logging', () => {
+      correlationIds.clearAll()
+      expect(correlationIds.debugLoggingEnabled).toBe(false)
+      correlationIds.debugLoggingEnabled = true
+      expect(correlationIds.debugLoggingEnabled).toBe(true)
+      expect(correlationIds.get()).toEqual({
+        'debug-log-enabled': 'true'
+      })
+    })
+  })
+
   describe('.replaceAllWith', () => {
     beforeEach(() => {
       correlationIds.set('x-correlation-id', 'this should be replaced')

--- a/packages/lambda-powertools-correlation-ids/index.js
+++ b/packages/lambda-powertools-correlation-ids/index.js
@@ -25,8 +25,12 @@ class CorrelationIds {
     return this.context
   }
 
-  get debugEnabled () {
+  get debugLoggingEnabled () {
     return this.context[DEBUG_LOG_ENABLED] === 'true'
+  }
+
+  set debugLoggingEnabled (enabled) {
+    this.context[DEBUG_LOG_ENABLED] = enabled ? 'true' : 'false'
   }
 
   static clearAll () {
@@ -44,7 +48,15 @@ class CorrelationIds {
   static get () {
     return globalCorrelationIds.get()
   }
-};
+
+  static get debugLoggingEnabled () {
+    return globalCorrelationIds.debugLoggingEnabled
+  }
+
+  static set debugLoggingEnabled (enabled) {
+    globalCorrelationIds.debugLoggingEnabled = enabled
+  }
+}
 
 if (!global.CORRELATION_IDS) {
   global.CORRELATION_IDS = new CorrelationIds()


### PR DESCRIPTION


Closes #237

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

CorrelationIds already had a convenience method for checking to see if `debug-log-enabled` was set, but no accompanying convenience method for setting said flag. In fact, the existing method looked to be unused and untested!


<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I've renamed the getter to be more meaningful (`debugEnabled` -> `debugLoggingEnabled`), added an associated setter, and added a test to show usage. In addition, I've updated the readme to show example usage.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Run tests!

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / projects / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
