### PR TITLE
feat(dynamodb-client): add word boundary in regex

### DIFF
--- a/packages/lambda-powertools-dynamodb-client/index.js
+++ b/packages/lambda-powertools-dynamodb-client/index.js
@@ -23,7 +23,7 @@ const addCorrelationIdsToUpdate = (correlationIds, params) => {
 
   // e.g. [ 'Add', '#count :value', 'REMOVE', 'Age' ]
   const exprSegments = updateExpr
-    .split(/(SET|REMOVE|ADD|REMOVE)/i)
+    .split(/\b(SET|REMOVE|ADD|REMOVE)\b/i)
     .filter(x => x)
     .map(x => x.trim())
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/dazn-lambda-powertools/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #242

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added word boundary `/b` in `exprSegments`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

The following UpdateExpression: 
`"SET #assets = list_append(if_not_exists(#assets, :empty_list), :assets)"`
Throw `"Invalid UpdateExpression: Syntax error; token: \",\", near: \"#as, #LambdaPowertoolsContext\""`

This happens because `exprSegments` without word boundaries produces the following result:
`["SET", "#as", "set", "s = list_append(if_not_exists(#as", "set", "s, :empty_list), :as", "set", "s)"]`

Adding the word boundary produces the expected result:
`["SET", "#assets = list_append(if_not_exists(#assets, :empty_list), :assets)"]`

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
